### PR TITLE
fix: SonarQube analysis step

### DIFF
--- a/.github/workflows/sonarqube.yaml
+++ b/.github/workflows/sonarqube.yaml
@@ -47,6 +47,14 @@ jobs:
         run: |
           dotnet tool install -g dotnet-reportgenerator-globaltool
 
+      - name: Run SonarQube Analysis
+        run: |
+          ./.sonar/scanner/dotnet-sonarscanner begin \
+            /k:"pontatot_EvilGiraf_cc00103c-92c6-4c02-beee-5ca0bd65407f" \
+            /d:sonar.token="${{ secrets.SONAR_TOKEN }}" \
+            /d:sonar.host.url="${{ secrets.SONAR_HOST_URL }}" \
+            /d:sonar.coverageReportPaths="./TestResults/CoverageReport/Cobertura.xml"
+
       - name: Build Project
         run: dotnet build
 
@@ -60,14 +68,6 @@ jobs:
             -reports:./TestResults/*/coverage.cobertura.xml \
             -targetdir:./TestResults/CoverageReport \
             -reporttypes:Cobertura
-
-      - name: Run SonarQube Analysis
-        run: |
-          ./.sonar/scanner/dotnet-sonarscanner begin \
-            /k:"pontatot_EvilGiraf_cc00103c-92c6-4c02-beee-5ca0bd65407f" \
-            /d:sonar.token="${{ secrets.SONAR_TOKEN }}" \
-            /d:sonar.host.url="${{ secrets.SONAR_HOST_URL }}" \
-            /d:sonar.coverageReportPaths="./TestResults/CoverageReport/Cobertura.xml"
 
       - name: Complete SonarQube Analysis
         run: |


### PR DESCRIPTION
Moved the SonarQube analysis step to run before building the project. This change ensures accurate code analysis and coverage reporting. The functionality remains unaffected; only the workflow order is updated.