### PR TITLE
fix: trigger workflow only on push events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: Tests
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   tests:


### PR DESCRIPTION
Removed pull_request from the workflow triggers to avoid redundant CI runs. This change ensures the tests run exclusively on push events, streamlining the CI process.