### PR TITLE
refactor: always enable Swagger UI and adjust Docker ports

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
 ﻿FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
 USER $APP_UID
 WORKDIR /app
-EXPOSE 8080
-EXPOSE 8081
 
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 ARG BUILD_CONFIGURATION=Release
@@ -19,5 +17,6 @@ RUN dotnet publish "EvilGiraf.csproj" -c "$BUILD_CONFIGURATION" -o /app/publish 
 
 FROM base AS final
 WORKDIR /app
+EXPOSE 8080
 COPY --from=publish /app/publish .
 ENTRYPOINT ["dotnet", "EvilGiraf.dll"]

--- a/EvilGiraf/Program.cs
+++ b/EvilGiraf/Program.cs
@@ -27,11 +27,8 @@ public class Program
         var app = builder.Build();
 
         // Configure the HTTP request pipeline.
-        if (app.Environment.IsDevelopment())
-        {
-            app.UseSwagger();
-            app.UseSwaggerUI();
-        }
+        app.UseSwagger();
+        app.UseSwaggerUI();
 
         app.UseHttpsRedirection();
 


### PR DESCRIPTION
Moved Swagger UI to always be enabled, regardless of environment, to simplify API testing. Adjusted Dockerfile to only expose port 8080 in the final stage for better clarity and alignment with runtime requirements.