### PR TITLE
feat: deployment service read

### DIFF
--- a/EvilGiraf/Interface/IDeploymentService.cs
+++ b/EvilGiraf/Interface/IDeploymentService.cs
@@ -6,6 +6,6 @@ namespace EvilGiraf.Interface;
 public interface IDeploymentService
 {
     public Task<V1Deployment> CreateDeployment(DeploymentModel model);
-
+    public Task<V1Deployment> ReadDeployment(string name, string @namespace);
     public Task<V1Status> DeleteDeployment(string name, string @namespace);
 }

--- a/EvilGiraf/Service/DeploymentService.cs
+++ b/EvilGiraf/Service/DeploymentService.cs
@@ -1,6 +1,8 @@
+using System.Net;
 using EvilGiraf.Interface;
 using EvilGiraf.Model;
 using k8s;
+using k8s.Autorest;
 using k8s.Models;
 
 namespace EvilGiraf.Service;
@@ -58,8 +60,24 @@ public class DeploymentService : IDeploymentService
         };
         return await _client.AppsV1.CreateNamespacedDeploymentAsync(deployment, model.Namespace);
     }
+    
+    public async Task<V1Deployment> ReadDeployment(string name, string @namespace)
+    {
+        try
+        {
+            var deployment = await _client.AppsV1.ReadNamespacedDeploymentAsync(name, @namespace);
+            return deployment;
+        }
+        catch (HttpOperationException e)
+        {
+            if (e.Response.StatusCode == HttpStatusCode.NotFound)
+            {
+                throw new KeyNotFoundException($"Deployment '{name}' not found in namespace '{@namespace}'");
+            }
+            throw;
+        }
+    }
 
-    // Delete deployment
     public async Task<V1Status> DeleteDeployment(string name, string @namespace)
     {
         return await _client.AppsV1.DeleteNamespacedDeploymentAsync(name, @namespace);


### PR DESCRIPTION
This pull request introduces new functionality for reading Kubernetes deployments in the `EvilGiraf` project. The changes include adding a new `ReadDeployment` method to the `IDeploymentService` interface and implementing it in the `DeploymentService` class. Additionally, several unit tests have been added to ensure the correct behavior of the new method.

### New functionality for reading deployments:

* [`EvilGiraf/Interface/IDeploymentService.cs`](diffhunk://#diff-16c403f0982b692823f0f77afd54dccb3c34464ee35b4f254aba15a9ead5c757R9): Added the `ReadDeployment` method to the `IDeploymentService` interface.
* [`EvilGiraf/Service/DeploymentService.cs`](diffhunk://#diff-02cdc6594c3102ede9efc5a7d72c29034ae011c71b9c7e30330ee833c7e003c8R63-R79): Implemented the `ReadDeployment` method to fetch a deployment by name and namespace, handling `HttpOperationException` to throw a `KeyNotFoundException` when the deployment is not found.

### Unit tests for the new functionality:

* [`EvilGiraf.Tests/DeploymentTests.cs`](diffhunk://#diff-f715284aff230341da89e33d2a10793e9062dabd4630b4d3d5c52c4e2a78f276R47-R143): Added multiple unit tests to verify the behavior of the `ReadDeployment` method, including tests for successful retrieval, handling of non-existent deployments, and validation of deployment name and namespace.

### Additional imports:

* [`EvilGiraf.Tests/DeploymentTests.cs`](diffhunk://#diff-f715284aff230341da89e33d2a10793e9062dabd4630b4d3d5c52c4e2a78f276R1): Added necessary imports for `System.Net` and `NSubstitute.ExceptionExtensions`. [[1]](diffhunk://#diff-f715284aff230341da89e33d2a10793e9062dabd4630b4d3d5c52c4e2a78f276R1) [[2]](diffhunk://#diff-f715284aff230341da89e33d2a10793e9062dabd4630b4d3d5c52c4e2a78f276R10)
* [`EvilGiraf/Service/DeploymentService.cs`](diffhunk://#diff-02cdc6594c3102ede9efc5a7d72c29034ae011c71b9c7e30330ee833c7e003c8R1-R5): Added necessary imports for `System.Net` and `k8s.Autorest`.

Closes #28 