### PR TITLE
chore(ci): update build latest workflow and job names to "Build Latest"

### DIFF
--- a/.github/workflows/build-latest.yml
+++ b/.github/workflows/build-latest.yml
@@ -1,12 +1,12 @@
-name: Build
+name: Build Latest
 on:
   push:
     branches:
       - main
 
 jobs:
-  build:
-    name: Build
+  build-latest:
+    name: Build Latest
     runs-on: ubuntu-latest
     
     steps:


### PR DESCRIPTION
Renamed the workflow and job from "Build" to "Build Latest" for clarity. This ensures better distinction when viewing workflows in the repository. No functional changes were introduced.