### PR TITLE
refactor(test): introduce service substitution in tests

### DIFF
--- a/EvilGiraf.IntegrationTests/SubstituteWebApplicationFactory.cs
+++ b/EvilGiraf.IntegrationTests/SubstituteWebApplicationFactory.cs
@@ -1,0 +1,20 @@
+using k8s;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using NSubstitute;
+
+namespace EvilGiraf.IntegrationTests;
+
+public class SubstituteWebApplicationFactory : WebApplicationFactory<Program>
+{
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.ConfigureServices(services =>
+        {
+            var descriptor = new ServiceDescriptor(typeof(IKubernetes), Substitute.For<IKubernetes>());
+            services.Replace(descriptor);
+        });
+    }
+}


### PR DESCRIPTION
Replaced `WebApplicationFactory` with `SubstituteWebApplicationFactory` to enable service substitution using NSubstitute. Updated tests to use the substituted `IKubernetes` service, allowing better control and isolation of Kubernetes-related dependencies. Simplified client creation in tests by utilizing the new factory.