### PR TITLE
feat(ci): add Kubernetes deployment workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,10 @@
 name: Build
-on: [push]
+on:
+  workflow_run:
+    workflows: [ "Tests" ]
+    types:
+      - completed
+  push:
 
 jobs:
   build:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,34 @@
+name: Deploy to Kubernetes
+on:
+  workflow_run:
+    workflows: ["Build"]
+    types:
+      - completed
+  push:
+    branches: [ main ]
+
+jobs:
+  deploy:
+    name: Deploy to Kubernetes
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Kubernetes config
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.KUBE_CONFIG }}" > ~/.kube/config
+          chmod 600 ~/.kube/config
+
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: 'latest'
+
+      - name: Deploy with Helm
+        run: |
+          helm upgrade --install evilgiraf helm-chart \
+            --namespace evilgiraf \
+            --create-namespace \
+            --set image.tag=${{ github.sha }} \
+            --wait --timeout 15m

--- a/.github/workflows/sonarqube.yaml
+++ b/.github/workflows/sonarqube.yaml
@@ -2,8 +2,7 @@ name: SonarQube
 
 on:
   push:
-    branches:
-      - main
+    branches: [ main ]
 
 jobs:
   sonarqube:


### PR DESCRIPTION
Introduce a GitHub Actions workflow to automate deployments to Kubernetes. It triggers on `main` branch pushes or upon completion of the "Build" workflow. The workflow uses Helm for deploying and supports dynamic image tags based on the latest commit SHA.

Closes #36 