### PR TITLE
fix: restrict CI workflows to 'main' branch and pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,6 @@ jobs:
   build:
     name: Build
     runs-on: github-runner
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     
     steps:
       - name: Checkout code

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,8 @@ on:
     workflows: [ "Tests" ]
     types:
       - completed
+    branches: main
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
     workflows: [ "Tests" ]
     types:
       - completed
-    branches: main
+    branches: [ main ]
   pull_request:
 
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,13 +1,13 @@
 name: Build
 
 on:
-  push:
-    branches-ignore: [ main ]
   workflow_run:
     workflows: [ "Tests" ]
     types:
       - completed
     branches: [ main ]
+  push:
+    branches-ignore: [ main ]
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,13 +1,13 @@
 name: Build
 
 on:
+  push:
+    branches-ignore: [ main ]
   workflow_run:
     workflows: [ "Tests" ]
     types:
       - completed
     branches: [ main ]
-  push:
-    branches-ignore: [ main ]
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,8 @@ on:
     types:
       - completed
     branches: [ main ]
-  pull_request:
+  push:
+    branches-ignore: [ main ]
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,13 +1,6 @@
 name: Build
 
-on:
-  workflow_run:
-    workflows: [ "Tests" ]
-    types:
-      - completed
-    branches: [ main ]
-  push:
-    branches-ignore: [ main ]
+on: [ push ]
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: Tests
 
-on: [push]
+on:
+  push:
+    branches: main
+  pull_request:
 
 jobs:
   tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: Tests
 
-on:
-  push:
-    branches: [ main ]
+on: [ push ]
 
 jobs:
   tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: Tests
 
-on: [ push ]
+on:
+  push:
+    branches: [ main ]
 
 jobs:
   tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,6 @@
 name: Tests
 
-on:
-  push:
-    branches: [ main ]
-  pull_request:
+on: [ push ]
 
 jobs:
   tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: Tests
 
 on:
   push:
-    branches: main
+    branches: [ main ]
   pull_request:
 
 jobs:


### PR DESCRIPTION
Updated GitHub workflows to trigger only on 'main' branch pushes and pull requests. This ensures CI processes run more efficiently and avoids unnecessary runs on other branches.