### PR TITLE
fix: configure Git user for tagging in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,8 @@ jobs:
       - name: Create Git Tag
         if: github.ref == 'refs/heads/main'
         run: |
+          git config user.email "gitversion@evilgiraf.com"
+          git config user.name "GitVersion"
           git tag -a v${{ steps.version.outputs.semVer }} -m "Release v${{ steps.version.outputs.semVer }}"
           git push origin v${{ steps.version.outputs.semVer }}
 


### PR DESCRIPTION
Add Git user email and name configuration to ensure proper tagging during the release process in the GitHub Actions workflow. This prevents potential issues with missing user identity in CI environments.