### PR TITLE
fix: update SonarQube project key and add scanAll parameter

### DIFF
--- a/.github/workflows/sonarqube.yaml
+++ b/.github/workflows/sonarqube.yaml
@@ -50,10 +50,11 @@ jobs:
       - name: Run SonarQube Analysis
         run: |
           ./.sonar/scanner/dotnet-sonarscanner begin \
-            /k:"pontatot_EvilGiraf_cc00103c-92c6-4c02-beee-5ca0bd65407f" \
+            /k:"EvilGiraf" \
             /d:sonar.token="${{ secrets.SONAR_TOKEN }}" \
             /d:sonar.host.url="${{ secrets.SONAR_HOST_URL }}" \
-            /d:sonar.cs.opencover.reportsPaths="**/coverage.opencover.xml"
+            /d:sonar.cs.opencover.reportsPaths="**/coverage.opencover.xml" \
+            /d:sonar.scanner.scanAll=true
 
       - name: Build Project
         run: dotnet build


### PR DESCRIPTION
The SonarQube key was changed to match the correct project identifier. Additionally, the `sonar.scanner.scanAll` parameter was added to ensure all files are included in the scan.