### PR TITLE
refactor: replace exceptions with null returns for not found cases

### DIFF
--- a/EvilGiraf.Tests/ApplicationServiceTests.cs
+++ b/EvilGiraf.Tests/ApplicationServiceTests.cs
@@ -47,7 +47,7 @@ public class ApplicationServiceTests
 
         // Assert
         result.Should().NotBeNull();
-        result.Id.Should().Be(createdApplication.Id);
+        result!.Id.Should().Be(createdApplication.Id);
         result.Name.Should().Be(applicationDto.Name);
         result.Type.Should().Be(applicationDto.Type);
         result.Link.Should().Be(applicationDto.Link);
@@ -55,13 +55,13 @@ public class ApplicationServiceTests
     }
 
     [Fact]
-    public async Task GetApplication_ShouldThrowKeyNotFoundException()
+    public async Task GetApplication_ShouldReturnNull()
     {
         // Act
-        Func<Task> act = async () => await _applicationService.GetApplication(999);
+        var result = await _applicationService.GetApplication(999);
 
         // Assert
-        await act.Should().ThrowAsync<KeyNotFoundException>().WithMessage("Application with id 999 not found");
+        result.Should().BeNull();
     }
 
     [Fact]
@@ -78,17 +78,17 @@ public class ApplicationServiceTests
         // Assert
         result.Should().NotBeNull();
 
-        Func<Task> act = async () => await _applicationService.GetApplication(createdApplication.Id);
-        await act.Should().ThrowAsync<KeyNotFoundException>().WithMessage("Application with id " + createdApplication.Id + " not found");
+        var app = await _applicationService.GetApplication(createdApplication.Id);
+        app.Should().BeNull();
     }
 
     [Fact]
-    public async Task DeleteApplication_ShouldThrowKeyNotFoundException()
+    public async Task DeleteApplication_ShouldReturnNull()
     {
         // Act
-        Func<Task> act = async () => await _applicationService.DeleteApplication(999);
+        var result = await _applicationService.DeleteApplication(999);
 
         // Assert
-        await act.Should().ThrowAsync<KeyNotFoundException>().WithMessage("Application with id 999 not found");
+        result.Should().BeNull();
     }
 }

--- a/EvilGiraf/Interface/IApplicationService.cs
+++ b/EvilGiraf/Interface/IApplicationService.cs
@@ -7,7 +7,7 @@ public interface IApplicationService
 {
     public Task<Application> CreateApplication(ApplicationDto applicationDto);
 
-    public Task<Application> GetApplication(int applicationId);
+    public Task<Application?> GetApplication(int applicationId);
 
-    public Task<Application> DeleteApplication(int applicationId);
+    public Task<Application?> DeleteApplication(int applicationId);
 }

--- a/EvilGiraf/Interface/IDeploymentService.cs
+++ b/EvilGiraf/Interface/IDeploymentService.cs
@@ -6,8 +6,10 @@ namespace EvilGiraf.Interface;
 public interface IDeploymentService
 {
     public Task<V1Deployment> CreateDeployment(DeploymentModel model);
-    public Task<V1Deployment> ReadDeployment(string name, string @namespace);
-    public Task<V1Status> DeleteDeployment(string name, string @namespace);
-
-    public Task<V1Deployment> UpdateDeployment(DeploymentModel model);
+    
+    public Task<V1Deployment?> ReadDeployment(string name, string @namespace);
+    
+    public Task<V1Deployment?> UpdateDeployment(DeploymentModel model);
+    
+    public Task<V1Status?> DeleteDeployment(string name, string @namespace);
 }

--- a/EvilGiraf/Model/DeploymentModel.cs
+++ b/EvilGiraf/Model/DeploymentModel.cs
@@ -1,3 +1,52 @@
+using k8s.Models;
+
 namespace EvilGiraf.Model;
 
 public record DeploymentModel(string Name, string Namespace, int Replicas, string Image, int[] Ports);
+
+public static class DeploymentModelExtensions
+{
+    public static V1Deployment ToDeployment(this DeploymentModel model)
+    {
+        return new V1Deployment
+        {
+            Metadata = new V1ObjectMeta
+            {
+                Name = model.Name
+            },
+            Spec = new V1DeploymentSpec
+            {
+                Replicas = model.Replicas,
+                Selector = new V1LabelSelector
+                {
+                    MatchLabels = new Dictionary<string, string>
+                    {
+                        { "app", model.Name }
+                    }
+                },
+                Template = new V1PodTemplateSpec
+                {
+                    Metadata = new V1ObjectMeta
+                    {
+                        Labels = new Dictionary<string, string>
+                        {
+                            { "app", model.Name }
+                        }
+                    },
+                    Spec = new V1PodSpec
+                    {
+                        Containers = new List<V1Container>
+                        {
+                            new()
+                            {
+                                Name = model.Name,
+                                Image = model.Image,
+                                Ports = model.Ports.Select(x => new V1ContainerPort(x)).ToList()
+                            }
+                        }
+                    }
+                }
+            }
+        };
+    }
+}

--- a/EvilGiraf/Service/ApplicationService.cs
+++ b/EvilGiraf/Service/ApplicationService.cs
@@ -1,6 +1,7 @@
 using EvilGiraf.Dto;
 using EvilGiraf.Interface;
 using EvilGiraf.Model;
+using Npgsql;
 
 namespace EvilGiraf.Service;
 
@@ -22,12 +23,19 @@ public class ApplicationService(DatabaseService databaseService) : IApplicationS
 
     public async Task<Application?> GetApplication(int applicationId)
     {
-        return await databaseService.Applications.FindAsync(applicationId);
+        try
+        {
+            return await databaseService.Applications.FindAsync(applicationId);
+        }
+        catch (PostgresException)
+        {
+            return null;
+        }
     }
 
     public async Task<Application?> DeleteApplication(int applicationId)
     {
-        var application = await databaseService.Applications.FindAsync(applicationId);
+        var application = await GetApplication(applicationId);
 
         if (application is null)
             return null;

--- a/EvilGiraf/Service/ApplicationService.cs
+++ b/EvilGiraf/Service/ApplicationService.cs
@@ -20,31 +20,20 @@ public class ApplicationService(DatabaseService databaseService) : IApplicationS
         return result.Entity;
     }
 
-    public async Task<Application> GetApplication(int applicationId)
+    public async Task<Application?> GetApplication(int applicationId)
     {
-        var application = await databaseService.Applications.FindAsync(applicationId);
-
-        if (application == null)
-        {
-            throw new KeyNotFoundException($"Application with id {applicationId} not found");
-        }
-        else {
-            return application;
-        }
+        return await databaseService.Applications.FindAsync(applicationId);
     }
 
-    public async Task<Application> DeleteApplication(int applicationId)
+    public async Task<Application?> DeleteApplication(int applicationId)
     {
         var application = await databaseService.Applications.FindAsync(applicationId);
 
-        if (application == null)
-        {
-            throw new KeyNotFoundException($"Application with id {applicationId} not found");
-        }
-        else {
-            databaseService.Applications.Remove(application);
-            await databaseService.SaveChangesAsync();
-            return application;
-        }
+        if (application is null)
+            return null;
+        
+        databaseService.Applications.Remove(application);
+        await databaseService.SaveChangesAsync();
+        return application;
     }
 }

--- a/EvilGiraf/Service/DeploymentService.cs
+++ b/EvilGiraf/Service/DeploymentService.cs
@@ -6,65 +6,18 @@ using k8s.Models;
 
 namespace EvilGiraf.Service;
 
-public class DeploymentService : IDeploymentService
+public class DeploymentService(IKubernetes client) : IDeploymentService
 {
-    private readonly IKubernetes _client;
-    
-    public DeploymentService(IKubernetes client)
-    {
-        _client = client;
-    }
-    
     public async Task<V1Deployment> CreateDeployment(DeploymentModel model)
     {
-        var deployment = new V1Deployment
-        {
-            Metadata = new V1ObjectMeta
-            {
-                Name = model.Name
-            },
-            Spec = new V1DeploymentSpec
-            {
-                Replicas = model.Replicas,
-                Selector = new V1LabelSelector
-                {
-                    MatchLabels = new Dictionary<string, string>
-                    {
-                        { "app", model.Name }
-                    }
-                },
-                Template = new V1PodTemplateSpec
-                {
-                    Metadata = new V1ObjectMeta
-                    {
-                        Labels = new Dictionary<string, string>
-                        {
-                            { "app", model.Name }
-                        }
-                    },
-                    Spec = new V1PodSpec
-                    {
-                        Containers = new List<V1Container>
-                        {
-                            new()
-                            {
-                                Name = model.Name,
-                                Image = model.Image,
-                                Ports = model.Ports.Select(x => new V1ContainerPort(x)).ToList()
-                            }
-                        }
-                    }
-                }
-            }
-        };
-        return await _client.AppsV1.CreateNamespacedDeploymentAsync(deployment, model.Namespace);
+        return await client.AppsV1.CreateNamespacedDeploymentAsync(model.ToDeployment(), model.Namespace);
     }
     
     public async Task<V1Deployment?> ReadDeployment(string name, string @namespace)
     {
         try
         {
-            var deployment = await _client.AppsV1.ReadNamespacedDeploymentAsync(name, @namespace);
+            var deployment = await client.AppsV1.ReadNamespacedDeploymentAsync(name, @namespace);
             return deployment;
         }
         catch (HttpOperationException)
@@ -77,7 +30,7 @@ public class DeploymentService : IDeploymentService
     {
         try
         {
-            return await _client.AppsV1.DeleteNamespacedDeploymentAsync(name, @namespace);
+            return await client.AppsV1.DeleteNamespacedDeploymentAsync(name, @namespace);
         }
         catch (HttpOperationException)
         {
@@ -87,49 +40,9 @@ public class DeploymentService : IDeploymentService
 
     public async Task<V1Deployment?> UpdateDeployment(DeploymentModel model)
     {
-        var deployment = new V1Deployment
-        {
-            Metadata = new V1ObjectMeta
-            {
-                Name = model.Name
-            },
-            Spec = new V1DeploymentSpec
-            {
-                Replicas = model.Replicas,
-                Selector = new V1LabelSelector
-                {
-                    MatchLabels = new Dictionary<string, string>
-                    {
-                        { "app", model.Name }
-                    }
-                },
-                Template = new V1PodTemplateSpec
-                {
-                    Metadata = new V1ObjectMeta
-                    {
-                        Labels = new Dictionary<string, string>
-                        {
-                            { "app", model.Name }
-                        }
-                    },
-                    Spec = new V1PodSpec
-                    {
-                        Containers = new List<V1Container>
-                        {
-                            new()
-                            {
-                                Name = model.Name,
-                                Image = model.Image,
-                                Ports = model.Ports.Select(x => new V1ContainerPort(x)).ToList()
-                            }
-                        }
-                    }
-                }
-            }
-        };
         try
         {
-            return await _client.AppsV1.ReplaceNamespacedDeploymentAsync(deployment, model.Name, model.Namespace);
+            return await client.AppsV1.ReplaceNamespacedDeploymentAsync(model.ToDeployment(), model.Name, model.Namespace);
         }
         catch (HttpOperationException)
         {

--- a/EvilGiraf/Service/DeploymentService.cs
+++ b/EvilGiraf/Service/DeploymentService.cs
@@ -1,4 +1,3 @@
-using System.Net;
 using EvilGiraf.Interface;
 using EvilGiraf.Model;
 using k8s;
@@ -61,29 +60,32 @@ public class DeploymentService : IDeploymentService
         return await _client.AppsV1.CreateNamespacedDeploymentAsync(deployment, model.Namespace);
     }
     
-    public async Task<V1Deployment> ReadDeployment(string name, string @namespace)
+    public async Task<V1Deployment?> ReadDeployment(string name, string @namespace)
     {
         try
         {
             var deployment = await _client.AppsV1.ReadNamespacedDeploymentAsync(name, @namespace);
             return deployment;
         }
-        catch (HttpOperationException e)
+        catch (HttpOperationException)
         {
-            if (e.Response.StatusCode == HttpStatusCode.NotFound)
-            {
-                throw new KeyNotFoundException($"Deployment '{name}' not found in namespace '{@namespace}'");
-            }
-            throw;
+            return null;
         }
     }
 
-    public async Task<V1Status> DeleteDeployment(string name, string @namespace)
+    public async Task<V1Status?> DeleteDeployment(string name, string @namespace)
     {
-        return await _client.AppsV1.DeleteNamespacedDeploymentAsync(name, @namespace);
+        try
+        {
+            return await _client.AppsV1.DeleteNamespacedDeploymentAsync(name, @namespace);
+        }
+        catch (HttpOperationException)
+        {
+            return null;
+        }
     }
 
-    public async Task<V1Deployment> UpdateDeployment(DeploymentModel model)
+    public async Task<V1Deployment?> UpdateDeployment(DeploymentModel model)
     {
         var deployment = new V1Deployment
         {
@@ -125,6 +127,13 @@ public class DeploymentService : IDeploymentService
                 }
             }
         };
-        return await _client.AppsV1.ReplaceNamespacedDeploymentAsync(deployment, model.Name, model.Namespace);
+        try
+        {
+            return await _client.AppsV1.ReplaceNamespacedDeploymentAsync(deployment, model.Name, model.Namespace);
+        }
+        catch (HttpOperationException)
+        {
+            return null;
+        }
     }
 }


### PR DESCRIPTION
Updated services and tests to return `null` instead of throwing exceptions when entities like applications or deployments are not found. This change ensures cleaner error handling and simplifies the codebase. Adjusted corresponding interfaces, methods, and unit tests to align with the new behavior.