### PR TITLE
feat: add ApplicationController with dependency injection

### DIFF
--- a/EvilGiraf/Controller/ApplicationController.cs
+++ b/EvilGiraf/Controller/ApplicationController.cs
@@ -1,0 +1,11 @@
+using EvilGiraf.Interface;
+using Microsoft.AspNetCore.Mvc;
+
+namespace EvilGiraf.Controller;
+
+[ApiController]
+[Route("application")]
+public class ApplicationController(IApplicationService applicationService) : ControllerBase
+{
+    
+}


### PR DESCRIPTION
Introduce a new ApplicationController to handle application-level requests. This controller utilizes dependency injection for the IApplicationService interface, ensuring better modularity and testability.

Closes #66 