### PR TITLE
feat: Created route to get Application

### DIFF
--- a/EvilGiraf.IntegrationTests/ApplicationControllerTests.cs
+++ b/EvilGiraf.IntegrationTests/ApplicationControllerTests.cs
@@ -65,4 +65,52 @@ public class ApplicationControllerTests : IntegrationTestBase
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
+
+    [Fact]
+    public async Task Get_ShouldReturnApplication()
+    {
+        // Arrange
+        var createRequest = new ApplicationCreateDto("test-application", ApplicationType.Docker, "docker.io/test-application:latest", "1.0.0");
+
+        var response = await Client.PostAsJsonAsync("/application", createRequest);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        var application = await response.Content.ReadFromJsonAsync<Application>();
+        
+        application.Should().NotBeNull();
+
+        // Act
+        response = await Client.GetAsync($"/application/{application!.Id}");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var applicationDto = await response.Content.ReadFromJsonAsync<Application>();
+        
+        applicationDto.Should().NotBeNull();
+        applicationDto!.Name.Should().Be(application!.Name);
+        applicationDto.Type.Should().Be(application.Type);
+        applicationDto.Link.Should().Be(application.Link);
+        applicationDto.Version.Should().Be(application.Version);
+        applicationDto.Id.Should().Be(application.Id);
+    }
+
+    [Fact]
+    public async Task GetWithNonExistingId_ShouldReturnNotFound()
+    {
+        // Arrange
+        var createRequest = new ApplicationCreateDto("test-application", ApplicationType.Docker, "docker.io/test-application:latest", "1.0.0");
+
+        var response = await Client.PostAsJsonAsync("/application", createRequest);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        var application = await response.Content.ReadFromJsonAsync<Application>();
+        
+        application.Should().NotBeNull();
+
+        // Act
+        response = await Client.GetAsync($"/application/{application!.Id + 1}");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
 }

--- a/EvilGiraf.IntegrationTests/ApplicationControllerTests.cs
+++ b/EvilGiraf.IntegrationTests/ApplicationControllerTests.cs
@@ -70,17 +70,19 @@ public class ApplicationControllerTests : IntegrationTestBase
     public async Task Get_ShouldReturnApplication()
     {
         // Arrange
-        var createRequest = new ApplicationCreateDto("test-application", ApplicationType.Docker, "docker.io/test-application:latest", "1.0.0");
+        var application = new Application
+        {
+            Name = "test-application",
+            Type = ApplicationType.Docker,
+            Link = "docker.io/test-application:latest",
+            Version = "1.0.0"
+        };
 
-        var response = await Client.PostAsJsonAsync("/application", createRequest);
-
-        response.StatusCode.Should().Be(HttpStatusCode.Created);
-        var application = await response.Content.ReadFromJsonAsync<Application>();
-        
-        application.Should().NotBeNull();
+        _dbContext.Applications.Add(application);
+        await _dbContext.SaveChangesAsync();
 
         // Act
-        response = await Client.GetAsync($"/application/{application!.Id}");
+        var response = await Client.GetAsync($"/application/{application!.Id}");
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -98,17 +100,19 @@ public class ApplicationControllerTests : IntegrationTestBase
     public async Task GetWithNonExistingId_ShouldReturnNotFound()
     {
         // Arrange
-        var createRequest = new ApplicationCreateDto("test-application", ApplicationType.Docker, "docker.io/test-application:latest", "1.0.0");
+        var application = new Application
+        {
+            Name = "test-application",
+            Type = ApplicationType.Docker,
+            Link = "docker.io/test-application:latest",
+            Version = "1.0.0"
+        };
 
-        var response = await Client.PostAsJsonAsync("/application", createRequest);
-
-        response.StatusCode.Should().Be(HttpStatusCode.Created);
-        var application = await response.Content.ReadFromJsonAsync<Application>();
-        
-        application.Should().NotBeNull();
+        _dbContext.Applications.Add(application);
+        await _dbContext.SaveChangesAsync();
 
         // Act
-        response = await Client.GetAsync($"/application/{application!.Id + 1}");
+        var response = await Client.GetAsync($"/application/{application!.Id + 1}");
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);

--- a/EvilGiraf/Controller/ApplicationController.cs
+++ b/EvilGiraf/Controller/ApplicationController.cs
@@ -17,4 +17,16 @@ public class ApplicationController(IApplicationService applicationService) : Con
 
         return Created($"", application.ToDto());
     }
+
+    [HttpGet("{id:int}")]
+    [ProducesResponseType(typeof(ApplicationResultDto), 200)]
+    [ProducesResponseType(typeof(string), 404)]
+    public async Task<IActionResult> Get(int id)
+    {
+        var application = await applicationService.GetApplication(id);
+        if (application is null)
+            return NotFound($"Application {id} not found");
+
+        return Ok(application.ToDto());
+    }
 }


### PR DESCRIPTION
This pull request adds new functionality to the `ApplicationController` and its corresponding integration tests in `ApplicationControllerTests`. The most important changes include the addition of a `Get` method to retrieve an application by its ID and the corresponding tests to ensure the new functionality works correctly.

### New functionality in `ApplicationController`:

* Added a `Get` method to retrieve an application by its ID. This method returns an `Ok` status with the application data if found, or a `NotFound` status with an error message if the application does not exist.

### New tests in `ApplicationControllerTests`:

* Added a test `Get_ShouldReturnApplication` to verify that the `Get` method returns the correct application data and a status code of `Ok` when the application exists.
* Added a test `GetWithNonExistingId_ShouldReturnNotFound` to verify that the `Get` method returns a `NotFound` status when the application does not exist.