### PR TITLE
feat: add API Key authentication for securing endpoints

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -51,4 +51,5 @@ jobs:
             --namespace evilgiraf \
             --create-namespace \
             --set image.tag=${{ steps.version.outputs.semVer }} \
+            --set auth.apiKey=${{ secrets.API_KEY }} \
             --wait --timeout 15m

--- a/EvilGiraf.IntegrationTests/ApplicationControllerTests.cs
+++ b/EvilGiraf.IntegrationTests/ApplicationControllerTests.cs
@@ -7,7 +7,7 @@ using FluentAssertions;
 
 namespace EvilGiraf.IntegrationTests;
 
-public class ApplicationControllerTests : IntegrationTestBase
+public class ApplicationControllerTests : AuthenticatedTestBase
 {
     private readonly DatabaseService _dbContext;
 

--- a/EvilGiraf.IntegrationTests/AuthenticatedTestBase.cs
+++ b/EvilGiraf.IntegrationTests/AuthenticatedTestBase.cs
@@ -1,0 +1,9 @@
+namespace EvilGiraf.IntegrationTests;
+
+public abstract class AuthenticatedTestBase : IntegrationTestBase
+{
+    protected AuthenticatedTestBase(CustomWebApplicationFactory factory) : base(factory)
+    {
+        Client.DefaultRequestHeaders.Add("X-API-Key", "test-api-key");
+    }
+}

--- a/EvilGiraf.IntegrationTests/AuthenticationTests.cs
+++ b/EvilGiraf.IntegrationTests/AuthenticationTests.cs
@@ -1,0 +1,48 @@
+using System.Net;
+using FluentAssertions;
+
+namespace EvilGiraf.IntegrationTests;
+
+public class AuthenticationTests(CustomWebApplicationFactory factory) : IntegrationTestBase(factory)
+{
+    [Fact]
+    public async Task Request_WithoutApiKey_ShouldReturn401()
+    {
+        // Arrange
+        using var client = Factory.CreateClient(); // Create new client without auth headers
+
+        // Act
+        var response = await client.GetAsync("/application/1");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+    
+    [Fact]
+    public async Task Request_WithWrongApiKey_ShouldReturn401()
+    {
+        // Arrange
+        using var client = Factory.CreateClient();
+        client.DefaultRequestHeaders.Add("X-API-Key", "wrong-api-key");
+
+        // Act
+        var response = await client.GetAsync("/application/1");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+    
+    [Fact]
+    public async Task Request_WithEmptyApiKey_ShouldReturn401()
+    {
+        // Arrange
+        using var client = Factory.CreateClient();
+        client.DefaultRequestHeaders.Add("X-API-Key", ["", ""]); 
+
+        // Act
+        var response = await client.GetAsync("/application/1");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+}

--- a/EvilGiraf.IntegrationTests/CustomWebApplicationFactory.cs
+++ b/EvilGiraf.IntegrationTests/CustomWebApplicationFactory.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 using Testcontainers.PostgreSql;
@@ -15,6 +16,7 @@ public class CustomWebApplicationFactory : WebApplicationFactory<Program>, IAsyn
 {
     private readonly PostgreSqlContainer _dbContainer;
     private readonly IKubernetes _kubernetesClient;
+    public const string TestApiKey = "test-api-key";
 
     public CustomWebApplicationFactory()
     {
@@ -29,6 +31,14 @@ public class CustomWebApplicationFactory : WebApplicationFactory<Program>, IAsyn
 
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
+        builder.ConfigureAppConfiguration((_, config) =>
+        {
+            config.AddInMemoryCollection(new Dictionary<string, string>
+            {
+                ["ApiKey"] = TestApiKey
+            }!);
+        });
+
         builder.ConfigureTestServices(services =>
         {
             services.RemoveAll(typeof(IKubernetes));

--- a/EvilGiraf.IntegrationTests/DeploymentControllerTests.cs
+++ b/EvilGiraf.IntegrationTests/DeploymentControllerTests.cs
@@ -12,7 +12,7 @@ using NSubstitute.ExceptionExtensions;
 
 namespace EvilGiraf.IntegrationTests;
 
-public class DeploymentControllerTests : IntegrationTestBase
+public class DeploymentControllerTests : AuthenticatedTestBase
 {
     private readonly DatabaseService _dbContext;
     private readonly IKubernetes _kubernetes;

--- a/EvilGiraf/Authentication/ApiKeyAuthExtensions.cs
+++ b/EvilGiraf/Authentication/ApiKeyAuthExtensions.cs
@@ -1,0 +1,15 @@
+using Microsoft.AspNetCore.Authentication;
+
+namespace EvilGiraf.Authentication;
+
+public static class ApiKeyAuthExtensions
+{
+    public static AuthenticationBuilder AddApiKeyAuth(
+        this IServiceCollection services,
+        Action<ApiKeyAuthOptions> options)
+    {
+        return services.AddAuthentication(ApiKeyAuthOptions.DefaultScheme)
+            .AddScheme<ApiKeyAuthOptions, ApiKeyAuthHandler>(
+                ApiKeyAuthOptions.DefaultScheme, options);
+    }
+}

--- a/EvilGiraf/Authentication/ApiKeyAuthHandler.cs
+++ b/EvilGiraf/Authentication/ApiKeyAuthHandler.cs
@@ -1,0 +1,43 @@
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Options;
+
+namespace EvilGiraf.Authentication;
+
+public class ApiKeyAuthHandler(
+    IOptionsMonitor<ApiKeyAuthOptions> options,
+    ILoggerFactory logger,
+    UrlEncoder encoder)
+    : AuthenticationHandler<ApiKeyAuthOptions>(options, logger, encoder)
+{
+    private const string ApiKeyHeaderName = "X-API-Key";
+
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        if (!Request.Headers.TryGetValue(ApiKeyHeaderName, out var apiKeyHeaderValues))
+        {
+            return Task.FromResult(AuthenticateResult.Fail("API Key was not provided"));
+        }
+
+        var providedApiKey = apiKeyHeaderValues.FirstOrDefault();
+        if (apiKeyHeaderValues.Count == 0 || string.IsNullOrWhiteSpace(providedApiKey))
+        {
+            return Task.FromResult(AuthenticateResult.Fail("API Key was not provided"));
+        }
+
+        var apiKey = Options.ApiKey;
+
+        if (!apiKey.Equals(providedApiKey))
+        {
+            return Task.FromResult(AuthenticateResult.Fail("Invalid API Key"));
+        }
+
+        var claims = new[] { new Claim(ClaimTypes.Name, "ApiKeyUser") };
+        var identity = new ClaimsIdentity(claims, Scheme.Name);
+        var principal = new ClaimsPrincipal(identity);
+        var ticket = new AuthenticationTicket(principal, Scheme.Name);
+
+        return Task.FromResult(AuthenticateResult.Success(ticket));
+    }
+}

--- a/EvilGiraf/Authentication/ApiKeyAuthOptions.cs
+++ b/EvilGiraf/Authentication/ApiKeyAuthOptions.cs
@@ -1,0 +1,9 @@
+using Microsoft.AspNetCore.Authentication;
+
+namespace EvilGiraf.Authentication;
+
+public class ApiKeyAuthOptions : AuthenticationSchemeOptions
+{
+    public const string DefaultScheme = "ApiKey";
+    public string ApiKey { get; set; } = string.Empty;
+}

--- a/EvilGiraf/Controller/ApplicationController.cs
+++ b/EvilGiraf/Controller/ApplicationController.cs
@@ -2,9 +2,11 @@ using EvilGiraf.Interface;
 using Microsoft.AspNetCore.Mvc;
 using EvilGiraf.Dto;
 using EvilGiraf.Extensions;
+using Microsoft.AspNetCore.Authorization;
 
 namespace EvilGiraf.Controller;
 
+[Authorize]
 [ApiController]
 [Route("application")]
 public class ApplicationController(IApplicationService applicationService) : ControllerBase

--- a/EvilGiraf/Controller/DeploymentController.cs
+++ b/EvilGiraf/Controller/DeploymentController.cs
@@ -1,10 +1,12 @@
 using EvilGiraf.Dto;
 using EvilGiraf.Interface;
 using EvilGiraf.Model;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace EvilGiraf.Controller;
 
+[Authorize]
 [ApiController]
 [Route("")]
 public class DeploymentController(IDeploymentService deploymentService, IApplicationService applicationService) : ControllerBase

--- a/helm-chart/templates/deployment.yaml
+++ b/helm-chart/templates/deployment.yaml
@@ -40,6 +40,9 @@ spec:
             - name: http
               containerPort: {{ .Values.service.port }}
               protocol: TCP
+          env:
+            - name: ApiKey
+              value: {{ .Values.auth.apiKey }}
           livenessProbe:
             {{- toYaml .Values.livenessProbe | nindent 12 }}
           readinessProbe:

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -119,3 +119,6 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+auth:
+  apiKey: '***'


### PR DESCRIPTION
Introduced API Key-based authentication to enhance security across endpoints, with support for verification and Swagger integration. Updated integration tests and Helm charts to include key handling and validation. Controllers now enforce authorization through the new schema.

Closes #88 