### PR TITLE
65 application controller delete

### DIFF
--- a/EvilGiraf.IntegrationTests/ApplicationControllerTests.cs
+++ b/EvilGiraf.IntegrationTests/ApplicationControllerTests.cs
@@ -109,4 +109,54 @@ public class ApplicationControllerTests : IntegrationTestBase
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
+
+    [Fact]
+    public async Task Delete_ShouldDeleteApplication()
+    {
+        // Arrange
+        var application = new Application
+        {
+            Name = "test-application",
+            Type = ApplicationType.Docker,
+            Link = "docker.io/test-application:latest",
+            Version = "1.0.0"
+        };
+
+        _dbContext.Applications.Add(application);
+        await _dbContext.SaveChangesAsync();
+
+        // Act
+        var response = await Client.DeleteAsync($"/application/{application!.Id}");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        response = await Client.GetAsync($"/application/{application.Id}");
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task DeleteWithNonExistingId_ShouldReturnNotFound()
+    {
+        // Arrange
+        var application = new Application
+        {
+            Name = "test-application",
+            Type = ApplicationType.Docker,
+            Link = "docker.io/test-application:latest",
+            Version = "1.0.0"
+        };
+
+        _dbContext.Applications.Add(application);
+        await _dbContext.SaveChangesAsync();
+
+        application = await _dbContext.Applications.FindAsync(application.Id);
+        application.Should().NotBeNull();
+
+        // Act
+        var response = await Client.DeleteAsync($"/application/{application!.Id + 1}");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
 }

--- a/EvilGiraf.IntegrationTests/ApplicationControllerTests.cs
+++ b/EvilGiraf.IntegrationTests/ApplicationControllerTests.cs
@@ -126,35 +126,20 @@ public class ApplicationControllerTests : IntegrationTestBase
         await _dbContext.SaveChangesAsync();
 
         // Act
-        var response = await Client.DeleteAsync($"/application/{application!.Id}");
+        var response = await Client.DeleteAsync($"/application/{application.Id}");
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.NoContent);
 
-        response = await Client.GetAsync($"/application/{application.Id}");
-        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        var checkresponse = await Client.GetAsync($"/application/{application.Id}");
+        checkresponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
 
     [Fact]
     public async Task DeleteWithNonExistingId_ShouldReturnNotFound()
     {
-        // Arrange
-        var application = new Application
-        {
-            Name = "test-application",
-            Type = ApplicationType.Docker,
-            Link = "docker.io/test-application:latest",
-            Version = "1.0.0"
-        };
-
-        _dbContext.Applications.Add(application);
-        await _dbContext.SaveChangesAsync();
-
-        application = await _dbContext.Applications.FindAsync(application.Id);
-        application.Should().NotBeNull();
-
         // Act
-        var response = await Client.DeleteAsync($"/application/{application!.Id + 1}");
+        var response = await Client.DeleteAsync($"/application/{999}");
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);

--- a/EvilGiraf/Controller/ApplicationController.cs
+++ b/EvilGiraf/Controller/ApplicationController.cs
@@ -29,4 +29,17 @@ public class ApplicationController(IApplicationService applicationService) : Con
 
         return Ok(application.ToDto());
     }
+
+    [HttpDelete("{id:int}")]
+    [ProducesResponseType(204)]
+    [ProducesResponseType(typeof(string), 404)]
+    public async Task<IActionResult> Delete(int id)
+    {
+        var response = await applicationService.DeleteApplication(id);
+
+        if(response is null)
+            return NotFound($"Application {id} not found");
+
+        return NoContent();
+    }
 }


### PR DESCRIPTION
This pull request introduces new functionality for deleting applications in the `ApplicationController` and adds corresponding integration tests. The most important changes include the addition of a new `Delete` method in the controller and new test cases to verify the deletion functionality.

### New functionality for deleting applications:

* [`EvilGiraf/Controller/ApplicationController.cs`](diffhunk://#diff-bc696ba179cc89bff2b9790a26d4e4f57733d34afb290ff377446fa4577f6b92R32-R44): Added a new `Delete` method to handle HTTP DELETE requests for deleting applications by ID. This method returns a `204 No Content` status if the deletion is successful and a `404 Not Found` status if the application does not exist.

### Integration tests for deletion functionality:

* [`EvilGiraf.IntegrationTests/ApplicationControllerTests.cs`](diffhunk://#diff-d41f11456c621976336f13cf3d5fd3b37b8b6fa73ae592bb6cb9e2c180b36a1bR112-R146): Added two new test cases: `Delete_ShouldDeleteApplication` to verify that an application can be successfully deleted, and `DeleteWithNonExistingId_ShouldReturnNotFound` to ensure that attempting to delete a non-existing application returns a `404 Not Found` status.