### PR TITLE
fix: deployment missing dotnet-ef tool in base docker image

### DIFF
--- a/EvilGiraf/Dockerfile
+++ b/EvilGiraf/Dockerfile
@@ -3,6 +3,7 @@ ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
 COPY "EvilGiraf.csproj" .
 RUN dotnet restore "EvilGiraf.csproj"
+RUN dotnet tool install --global dotnet-ef
 COPY . .
 RUN dotnet build "EvilGiraf.csproj" -c $BUILD_CONFIGURATION -o /app/build
 RUN dotnet publish "EvilGiraf.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false


### PR DESCRIPTION
Include the global installation of the dotnet-ef tool to ensure Entity Framework CLI commands are available. This update streamlines development workflows that rely on EF migrations or schema management.