### PR TITLE
fix: update EF migrations command with correct dotnet-ef path

### DIFF
--- a/helm-chart/templates/deployment.yaml
+++ b/helm-chart/templates/deployment.yaml
@@ -40,7 +40,7 @@ spec:
               value: {{ .Values.postgresql.auth.password }}
         - name: ef-migrations
           image: "{{ .Values.app.baseImage.repository }}:{{ .Values.app.baseImage.tag | default .Chart.AppVersion }}"
-          command: ['dotnet', 'ef', 'database', 'update']
+          command: ['~/.dotnet/tools/dotnet-ef', 'database', 'update']
           env:
             - name: POSTGRES__HOST
               value: {{ .Release.Name }}-postgresql


### PR DESCRIPTION
The EF migrations command now uses the full path to the dotnet-ef tool, resolving potential issues with environment-dependent configurations. This ensures the migration command executes reliably and consistently.