### PR TITLE
fix: correct EF migrations command path

### DIFF
--- a/helm-chart/templates/deployment.yaml
+++ b/helm-chart/templates/deployment.yaml
@@ -40,7 +40,7 @@ spec:
               value: {{ .Values.postgresql.auth.password }}
         - name: ef-migrations
           image: "{{ .Values.app.baseImage.repository }}:{{ .Values.app.baseImage.tag | default .Chart.AppVersion }}"
-          command: ['~/.dotnet/tools/dotnet-ef', 'database', 'update']
+          command: ['/root/.dotnet/tools/dotnet-ef', 'database', 'update']
           env:
             - name: POSTGRES__HOST
               value: {{ .Release.Name }}-postgresql


### PR DESCRIPTION
Adjusted the EF migrations command path from `~/.dotnet` to `/root/.dotnet` to ensure compatibility with the container's directory structure. This resolves potential issues during database migration execution.