### PR TITLE
feat: add RBAC templates in helm chart for cluster roles

### DIFF
--- a/helm-chart/templates/rbac.yaml
+++ b/helm-chart/templates/rbac.yaml
@@ -1,0 +1,34 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "evil-giraf.fullname" . }}-role
+  labels:
+    {{- include "evil-giraf.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["pods", "configmaps", "secrets", "services", "persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "evil-giraf.fullname" . }}-rolebinding
+  labels:
+    {{- include "evil-giraf.labels" . | nindent 4 }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "evil-giraf.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "evil-giraf.fullname" . }}-role
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Introduce ClusterRole and ClusterRoleBinding templates to the Helm chart. These define permissions for namespaces, pods, configmaps, secrets, services, ingresses, and deployments. Ensures proper access control and aligns with Kubernetes best practices.