### PR TITLE
feat: add deployment status route

### DIFF
--- a/EvilGiraf.Tests/KubernetesTests.cs
+++ b/EvilGiraf.Tests/KubernetesTests.cs
@@ -1,0 +1,110 @@
+using EvilGiraf.Interface;
+using EvilGiraf.Model;
+using EvilGiraf.Service;
+using FluentAssertions;
+using k8s.Models;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+
+namespace EvilGiraf.Tests;
+
+public class KubernetesTests
+{
+    private readonly IDeploymentService _deploymentService;
+    private readonly KubernetesService _kubernetesService;
+
+    public KubernetesTests()
+    {
+        _deploymentService = Substitute.For<IDeploymentService>();
+        _kubernetesService = new KubernetesService(_deploymentService);
+    }
+
+    private static Application CreateTestApplication() => new()
+    {
+        Id = 1,
+        Name = "test-app",
+        Type = ApplicationType.Docker,
+        Link = "docker.io/test:latest",
+        Version = "1.0.0"
+    };
+
+    [Fact]
+    public async Task Deploy_ShouldCreateNewDeployment_WhenDeploymentDoesNotExist()
+    {
+        // Arrange
+        var app = CreateTestApplication();
+        _deploymentService.ReadDeployment(app.Name, app.Id.ToNamespace())
+            .Returns((V1Deployment?)null);
+        
+        _deploymentService.CreateDeployment(Arg.Any<DeploymentModel>())
+            .Returns(new V1Deployment());
+
+        // Act
+        await _kubernetesService.Deploy(app);
+
+        // Assert
+        await _deploymentService.Received(1)
+            .ReadDeployment(app.Name, app.Id.ToNamespace());
+        
+        await _deploymentService.Received(1)
+            .CreateDeployment(Arg.Is<DeploymentModel>(d => 
+                d.Name == app.Name && 
+                d.Namespace == app.Id.ToNamespace() &&
+                d.Image == app.Link &&
+                d.Replicas == 1));
+        
+        await _deploymentService.DidNotReceive()
+            .UpdateDeployment(Arg.Any<DeploymentModel>());
+    }
+
+    [Fact]
+    public async Task Deploy_ShouldUpdateDeployment_WhenDeploymentExists()
+    {
+        // Arrange
+        var app = CreateTestApplication();
+        _deploymentService.ReadDeployment(app.Name, app.Id.ToNamespace())
+            .Returns(new V1Deployment());
+        
+        _deploymentService.UpdateDeployment(Arg.Any<DeploymentModel>())
+            .Returns(new V1Deployment());
+
+        // Act
+        await _kubernetesService.Deploy(app);
+
+        // Assert
+        await _deploymentService.Received(1)
+            .ReadDeployment(app.Name, app.Id.ToNamespace());
+        
+        await _deploymentService.DidNotReceive()
+            .CreateDeployment(Arg.Any<DeploymentModel>());
+        
+        await _deploymentService.Received(1)
+            .UpdateDeployment(Arg.Is<DeploymentModel>(d => 
+                d.Name == app.Name && 
+                d.Namespace == app.Id.ToNamespace() &&
+                d.Image == app.Link &&
+                d.Replicas == 1));
+    }
+
+    [Fact]
+    public async Task Deploy_ShouldHandleDeploymentServiceErrors()
+    {
+        // Arrange
+        var app = CreateTestApplication();
+        _deploymentService.ReadDeployment(app.Name, app.Id.ToNamespace())
+            .ThrowsAsync(new Exception("Deployment service error"));
+
+        // Act
+        var act = () => _kubernetesService.Deploy(app);
+
+        // Assert
+        await act.Should().ThrowAsync<Exception>()
+            .WithMessage("Deployment service error");
+        
+        await _deploymentService.DidNotReceive()
+            .CreateDeployment(Arg.Any<DeploymentModel>());
+        
+        await _deploymentService.DidNotReceive()
+            .UpdateDeployment(Arg.Any<DeploymentModel>());
+    }
+}

--- a/EvilGiraf/Controller/DeploymentController.cs
+++ b/EvilGiraf/Controller/DeploymentController.cs
@@ -9,12 +9,26 @@ namespace EvilGiraf.Controller;
 [Authorize]
 [ApiController]
 [Route("")]
-public class DeploymentController(IDeploymentService deploymentService, IApplicationService applicationService) : ControllerBase
+public class DeploymentController(IDeploymentService deploymentService, IApplicationService applicationService, IKubernetesService kubernetesService) : ControllerBase
 {
     [HttpPost("application/{id:int}/deploy")]
-    [ProducesResponseType(typeof(DeployResponse), 201)]
+    [ProducesResponseType(201)]
     [ProducesResponseType(typeof(string), 404)]
     public async  Task<IActionResult> Deploy(int id)
+    {
+        var app = await applicationService.GetApplication(id);
+        if (app is null)
+            return NotFound($"Application {id} not found");
+        
+        _ = kubernetesService.Deploy(app);
+        
+        return Created($"application/{id:int}/deploy", null);
+    }
+    
+    [HttpGet("application/{id:int}/deploy")]
+    [ProducesResponseType(typeof(DeployResponse), 200)]
+    [ProducesResponseType(typeof(string), 404)]
+    public async  Task<IActionResult> Status(int id)
     {
         var app = await applicationService.GetApplication(id);
         if (app is null)
@@ -22,16 +36,8 @@ public class DeploymentController(IDeploymentService deploymentService, IApplica
 
         var deployment = await deploymentService.ReadDeployment(app.Name, app.Id.ToNamespace());
         if (deployment is null)
-        {
-            deployment = await deploymentService.CreateDeployment(new DeploymentModel(app.Name, app.Id.ToNamespace(), 1,
-                app.Link, []));
-        }
-        else
-        {
-            await deploymentService.UpdateDeployment(new DeploymentModel(app.Name, app.Id.ToNamespace(), 1,
-                app.Link, []));
-        }
+            return NotFound($"Application {id} is not deployed");
         
-        return Created($"application/{id:int}/deploy", new DeployResponse(deployment.Status));
+        return Ok(new DeployResponse(deployment.Status));
     }
 }

--- a/EvilGiraf/Interface/IKubernetesService.cs
+++ b/EvilGiraf/Interface/IKubernetesService.cs
@@ -1,0 +1,8 @@
+using EvilGiraf.Model;
+
+namespace EvilGiraf.Interface;
+
+public interface IKubernetesService
+{
+    public Task Deploy(Application app);
+}

--- a/EvilGiraf/Program.cs
+++ b/EvilGiraf/Program.cs
@@ -63,6 +63,7 @@ public class Program
                 .Get<NpgsqlConnectionStringBuilder>()?.ConnectionString));
         builder.Services.AddSingleton<IDeploymentService, DeploymentService>();
         builder.Services.AddScoped<IApplicationService, ApplicationService>();
+        builder.Services.AddScoped<IKubernetesService, KubernetesService>();
 
         var app = builder.Build();
 

--- a/EvilGiraf/Service/KubernetesService.cs
+++ b/EvilGiraf/Service/KubernetesService.cs
@@ -1,0 +1,22 @@
+using EvilGiraf.Interface;
+using EvilGiraf.Model;
+
+namespace EvilGiraf.Service;
+
+public class KubernetesService(IDeploymentService deploymentService) : IKubernetesService
+{
+    public async Task Deploy(Application app)
+    {
+        var deployment = await deploymentService.ReadDeployment(app.Name, app.Id.ToNamespace());
+        if (deployment is null)
+        {
+            await deploymentService.CreateDeployment(new DeploymentModel(app.Name, app.Id.ToNamespace(), 1,
+                app.Link, []));
+        }
+        else
+        {
+            await deploymentService.UpdateDeployment(new DeploymentModel(app.Name, app.Id.ToNamespace(), 1,
+                app.Link, []));
+        }
+    }
+}


### PR DESCRIPTION
Introduce `KubernetesService` to manage application deployments via `IDeploymentService`. Updated `DeploymentController` with a new endpoint to fetch deployment status and integrated `KubernetesService` into deployment tasks. Added unit and integration tests for deployment and status handling.

Closes #109 