### PR TITLE
chore: update CI to use setup-dotnet v4 and enable caching

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,6 +18,8 @@ jobs:
         with:
           dotnet-version: '8.0.x'
           cache: true
+        env:
+          DOTNET_ROOT: ${{ runner.temp }}/dotnet
 
       - name: Install dependencies
         run: dotnet restore --locked-mode
@@ -118,6 +120,8 @@ jobs:
         with:
           dotnet-version: '8.0.x'
           cache: true
+        env:
+          DOTNET_ROOT: ${{ runner.temp }}/dotnet
 
       - name: Install GitVersion
         uses: gittools/actions/gitversion/setup@v3.1.11

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,12 +14,13 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '8.0.x'
+          cache: true
 
       - name: Install dependencies
-        run: dotnet restore
+        run: dotnet restore --locked-mode
 
       - name: Run unit tests
         run: dotnet test
@@ -113,9 +114,10 @@ jobs:
           distribution: 'zulu'
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '8.0.x'
+          cache: true
 
       - name: Install GitVersion
         uses: gittools/actions/gitversion/setup@v3.1.11
@@ -158,6 +160,9 @@ jobs:
             /d:sonar.host.url="${{ secrets.SONAR_HOST_URL }}" \
             /d:sonar.cs.opencover.reportsPaths="**/coverage.opencover.xml" \
             /d:sonar.scanner.scanAll=true
+
+      - name: Install dependencies
+        run: dotnet restore --locked-mode
 
       - name: Build Project
         run: dotnet build


### PR DESCRIPTION
Upgraded setup-dotnet action to v4 and enabled caching for improved performance. Updated `dotnet restore` to use `--locked-mode` for dependency consistency. Added a missing `dotnet restore` step before building the project in one workflow.