### PR TITLE
108 application controller list

### DIFF
--- a/EvilGiraf.IntegrationTests/ApplicationControllerTests.cs
+++ b/EvilGiraf.IntegrationTests/ApplicationControllerTests.cs
@@ -4,6 +4,7 @@ using EvilGiraf.Dto;
 using EvilGiraf.Model;
 using EvilGiraf.Service;
 using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
 
 namespace EvilGiraf.IntegrationTests;
 
@@ -244,5 +245,76 @@ public class ApplicationControllerTests : AuthenticatedTestBase
         savedApplication.Type.Should().Be(application.Type);
         savedApplication.Link.Should().Be(application.Link);
         savedApplication.Version.Should().Be(application.Version);
+    }
+
+    [Fact]
+    public async Task List_ShouldReturnListOfApplications()
+    {
+        // Arrange
+        var old_applications = await _dbContext.Applications.ToListAsync();
+        _dbContext.Applications.RemoveRange(old_applications);
+        await _dbContext.SaveChangesAsync();
+
+        var applications = new List<Application>
+        {
+            new Application
+            {
+                Name = "test-application-1",
+                Type = ApplicationType.Docker,
+                Link = "docker.io/test-application-1:latest",
+                Version = "1.0.0"
+            },
+            new Application
+            {
+                Name = "test-application-2",
+                Type = ApplicationType.Git,
+                Link = "k8s.io/test-application-2:latest",
+                Version = "2.0.0"
+            }
+        };
+
+        _dbContext.Applications.AddRange(applications);
+        await _dbContext.SaveChangesAsync();
+
+        // Act
+        var response = await Client.GetAsync("/application");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var applicationDtos = await response.Content.ReadFromJsonAsync<List<Application>>();
+
+        applicationDtos.Should().NotBeNull();
+        applicationDtos.Should().HaveCount(2);
+
+        applicationDtos![0].Name.Should().Be(applications[0].Name);
+        applicationDtos[0].Type.Should().Be(applications[0].Type);
+        applicationDtos[0].Link.Should().Be(applications[0].Link);
+        applicationDtos[0].Version.Should().Be(applications[0].Version);
+        applicationDtos[0].Id.Should().Be(applications[0].Id);
+
+        applicationDtos[1].Name.Should().Be(applications[1].Name);
+        applicationDtos[1].Type.Should().Be(applications[1].Type);
+        applicationDtos[1].Link.Should().Be(applications[1].Link);
+        applicationDtos[1].Version.Should().Be(applications[1].Version);
+        applicationDtos[1].Id.Should().Be(applications[1].Id);
+    }
+
+    [Fact]
+    public async Task ListWithNoApplications_ShouldReturnEmptyList()
+    {
+        // Arrange
+        var old_applications = await _dbContext.Applications.ToListAsync();
+        _dbContext.Applications.RemoveRange(old_applications);
+        await _dbContext.SaveChangesAsync();
+        
+        // Act
+        var response = await Client.GetAsync("/application");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var applicationDtos = await response.Content.ReadFromJsonAsync<List<Application>>();
+
+        applicationDtos.Should().NotBeNull();
+        applicationDtos.Should().BeEmpty();
     }
 }

--- a/EvilGiraf.IntegrationTests/ApplicationControllerTests.cs
+++ b/EvilGiraf.IntegrationTests/ApplicationControllerTests.cs
@@ -251,20 +251,20 @@ public class ApplicationControllerTests : AuthenticatedTestBase
     public async Task List_ShouldReturnListOfApplications()
     {
         // Arrange
-        var old_applications = await _dbContext.Applications.ToListAsync();
-        _dbContext.Applications.RemoveRange(old_applications);
+        var oldApplications = await _dbContext.Applications.ToListAsync();
+        _dbContext.Applications.RemoveRange(oldApplications);
         await _dbContext.SaveChangesAsync();
 
         var applications = new List<Application>
         {
-            new Application
+            new()
             {
                 Name = "test-application-1",
                 Type = ApplicationType.Docker,
                 Link = "docker.io/test-application-1:latest",
                 Version = "1.0.0"
             },
-            new Application
+            new()
             {
                 Name = "test-application-2",
                 Type = ApplicationType.Git,
@@ -303,8 +303,8 @@ public class ApplicationControllerTests : AuthenticatedTestBase
     public async Task ListWithNoApplications_ShouldReturnEmptyList()
     {
         // Arrange
-        var old_applications = await _dbContext.Applications.ToListAsync();
-        _dbContext.Applications.RemoveRange(old_applications);
+        var oldApplications = await _dbContext.Applications.ToListAsync();
+        _dbContext.Applications.RemoveRange(oldApplications);
         await _dbContext.SaveChangesAsync();
         
         // Act

--- a/EvilGiraf.Tests/ApplicationServiceTests.cs
+++ b/EvilGiraf.Tests/ApplicationServiceTests.cs
@@ -153,8 +153,8 @@ public class ApplicationServiceTests
     public async Task ListApplications_ShouldReturnListOfApplications()
     {
         // Arrange
-        var appalications = await _applicationService.ListApplications();
-        foreach (var app in appalications)
+        var applications = await _applicationService.ListApplications();
+        foreach (var app in applications)
         {
             await _applicationService.DeleteApplication(app.Id);
         }
@@ -179,8 +179,8 @@ public class ApplicationServiceTests
     public async Task ListApplications_ShouldReturnEmptyList()
     {
         // Arrange
-        var appalications = await _applicationService.ListApplications();
-        foreach (var app in appalications)
+        var applications = await _applicationService.ListApplications();
+        foreach (var app in applications)
         {
             await _applicationService.DeleteApplication(app.Id);
         }

--- a/EvilGiraf.Tests/ApplicationServiceTests.cs
+++ b/EvilGiraf.Tests/ApplicationServiceTests.cs
@@ -135,17 +135,61 @@ public class ApplicationServiceTests
         result.Version.Should().Be(applicationDto.Version);
     }
     
-        [Fact]
-        public async Task UpdateApplication_ShouldReturnNull_WhenApplicationDoesNotExist()
+    [Fact]
+    public async Task UpdateApplication_ShouldReturnNull_WhenApplicationDoesNotExist()
+    {
+        // Arrange
+        var updatedApplicationDto = new ApplicationUpdateDto(
+            "UpdatedTestApp", ApplicationType.Docker, "https://updatedtest.com", "2.0.0");
+
+        // Act
+        var result = await _applicationService.UpdateApplication(999, updatedApplicationDto);
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ListApplications_ShouldReturnListOfApplications()
+    {
+        // Arrange
+        var appalications = await _applicationService.ListApplications();
+        foreach (var app in appalications)
         {
-            // Arrange
-            var updatedApplicationDto = new ApplicationUpdateDto(
-                "UpdatedTestApp", ApplicationType.Docker, "https://updatedtest.com", "2.0.0");
-    
-            // Act
-            var result = await _applicationService.UpdateApplication(999, updatedApplicationDto);
-    
-            // Assert
-            result.Should().BeNull();
+            await _applicationService.DeleteApplication(app.Id);
         }
+
+        var application1 = new ApplicationCreateDto("TestApp1", ApplicationType.Docker, "https://test.com", "1.0.0");
+        var application2 = new ApplicationCreateDto("TestApp2", ApplicationType.Docker, "https://test.com", "1.0.0");
+        var application3 = new ApplicationCreateDto("TestApp3", ApplicationType.Docker, "https://test.com", "1.0.0");
+
+        await _applicationService.CreateApplication(application1);
+        await _applicationService.CreateApplication(application2);
+        await _applicationService.CreateApplication(application3);
+
+        // Act
+        var result = await _applicationService.ListApplications();
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().HaveCount(3);
+    }
+
+    [Fact]
+    public async Task ListApplications_ShouldReturnEmptyList()
+    {
+        // Arrange
+        var appalications = await _applicationService.ListApplications();
+        foreach (var app in appalications)
+        {
+            await _applicationService.DeleteApplication(app.Id);
+        }
+        
+        // Act
+        var result = await _applicationService.ListApplications();
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().HaveCount(0);
+    }
 }

--- a/EvilGiraf/Controller/ApplicationController.cs
+++ b/EvilGiraf/Controller/ApplicationController.cs
@@ -57,4 +57,13 @@ public class ApplicationController(IApplicationService applicationService) : Con
 
         return Ok(application.ToDto());
     }
+
+    [HttpGet("")]
+    [ProducesResponseType(typeof(List<ApplicationResultDto>), 200)]
+    public async Task<IActionResult> List()
+    {
+        var applications = await applicationService.ListApplications();
+
+        return Ok(applications.Select(a => a.ToDto()));
+    }
 }

--- a/EvilGiraf/Interface/IApplicationService.cs
+++ b/EvilGiraf/Interface/IApplicationService.cs
@@ -12,4 +12,6 @@ public interface IApplicationService
     public Task<Application?> DeleteApplication(int applicationId);
     
     public Task<Application?> UpdateApplication(int applicationId, ApplicationUpdateDto applicationUpdateDto);
+
+    public Task<List<Application>> ListApplications();
 }

--- a/EvilGiraf/Service/ApplicationService.cs
+++ b/EvilGiraf/Service/ApplicationService.cs
@@ -2,6 +2,7 @@ using EvilGiraf.Dto;
 using EvilGiraf.Extensions;
 using EvilGiraf.Interface;
 using EvilGiraf.Model;
+using Microsoft.EntityFrameworkCore;
 
 namespace EvilGiraf.Service;
 
@@ -47,5 +48,10 @@ public class ApplicationService(DatabaseService databaseService) : IApplicationS
         var updatedApp = databaseService.Applications.Update(application).Entity;
         await databaseService.SaveChangesAsync();
         return updatedApp;
+    }
+
+    public async Task<List<Application>> ListApplications()
+    {
+        return await databaseService.Applications.ToListAsync();
     }
 }


### PR DESCRIPTION
This pull request introduces new functionality to list applications and includes several related changes across multiple files. The most important changes are the addition of new methods and tests for listing applications.

### New functionality to list applications:

* [`EvilGiraf/Controller/ApplicationController.cs`](diffhunk://#diff-bc696ba179cc89bff2b9790a26d4e4f57733d34afb290ff377446fa4577f6b92R60-R68): Added a new `List` method to the `ApplicationController` to handle GET requests and return a list of applications.
* [`EvilGiraf/Interface/IApplicationService.cs`](diffhunk://#diff-9eb241e00a1d072ed8efebd7247803d15e31533d4629d21fa589522be74f4453R15-R16): Added a new `ListApplications` method to the `IApplicationService` interface.
* [`EvilGiraf/Service/ApplicationService.cs`](diffhunk://#diff-95eea49efe747bf2736104f00deb191b248baeedba011585410752e67f142541R52-R56): Implemented the `ListApplications` method in the `ApplicationService` class to retrieve the list of applications from the database.

### Tests for listing applications:

* [`EvilGiraf.IntegrationTests/ApplicationControllerTests.cs`](diffhunk://#diff-d41f11456c621976336f13cf3d5fd3b37b8b6fa73ae592bb6cb9e2c180b36a1bR249-R319): Added integration tests for the `List` method to ensure it returns the correct list of applications and handles cases with no applications.
* [`EvilGiraf.Tests/ApplicationServiceTests.cs`](diffhunk://#diff-c0d5bc04e94f35b81dc2cb41eed915b587d3e22b454584f9e8c1af60dfb74146R151-R194): Added unit tests for the `ListApplications` method to verify it returns the correct list of applications and handles cases with no applications.

### Additional changes:

* `EvilGiraf.IntegrationTests/ApplicationControllerTests.cs` and `EvilGiraf/Service/ApplicationService.cs`: Added `Microsoft.EntityFrameworkCore` using directives to support asynchronous database operations. [[1]](diffhunk://#diff-d41f11456c621976336f13cf3d5fd3b37b8b6fa73ae592bb6cb9e2c180b36a1bR7) [[2]](diffhunk://#diff-95eea49efe747bf2736104f00deb191b248baeedba011585410752e67f142541R5)

closes #108 