### PR TITLE
refactor: simplify deployment endpoint routes

### DIFF
--- a/EvilGiraf.IntegrationTests/DeploymentControllerTests.cs
+++ b/EvilGiraf.IntegrationTests/DeploymentControllerTests.cs
@@ -61,7 +61,7 @@ public class DeploymentControllerTests : AuthenticatedTestBase
             .Returns(deployment);
 
         // Act
-        var response = await Client.PostAsync($"/application/{application.Id}/deploy", null);
+        var response = await Client.PostAsync($"/deploy/{application.Id}", null);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Created);
@@ -121,7 +121,7 @@ public class DeploymentControllerTests : AuthenticatedTestBase
         _kubernetes.CoreV1.ReadNamespaceWithHttpMessagesAsync(Arg.Any<string>()).Returns(new HttpOperationResponse<V1Namespace>());
         
         // Act
-        var response = await Client.PostAsync($"/application/{application.Id}/deploy", null);
+        var response = await Client.PostAsync($"/deploy/{application.Id}", null);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Created);
@@ -135,7 +135,7 @@ public class DeploymentControllerTests : AuthenticatedTestBase
     public async Task Deploy_ShouldReturn404_WhenApplicationDoesNotExist()
     {
         // Act
-        var response = await Client.PostAsync("/application/999/deploy", null);
+        var response = await Client.PostAsync("/deploy/999", null);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
@@ -175,7 +175,7 @@ public class DeploymentControllerTests : AuthenticatedTestBase
             .Returns(deployment);
 
         // Act
-        var response = await Client.GetAsync($"/application/{application.Id}/deploy");
+        var response = await Client.GetAsync($"/deploy/{application.Id}");
 
         // Assert
         response.Should().BeSuccessful();
@@ -210,7 +210,7 @@ public class DeploymentControllerTests : AuthenticatedTestBase
             .Throws(httpException);
 
         // Act
-        var response = await Client.GetAsync($"/application/{application.Id}/deploy");
+        var response = await Client.GetAsync($"/deploy/{application.Id}");
 
         // Assert
         response.Should().HaveStatusCode(HttpStatusCode.NotFound);
@@ -225,7 +225,7 @@ public class DeploymentControllerTests : AuthenticatedTestBase
         const int nonExistentApplicationId = 999;
 
         // Act
-        var response = await Client.GetAsync($"/application/{nonExistentApplicationId}/deploy");
+        var response = await Client.GetAsync($"/deploy/{nonExistentApplicationId}");
 
         // Assert
         response.Should().HaveStatusCode(HttpStatusCode.NotFound);

--- a/EvilGiraf/Controller/DeploymentController.cs
+++ b/EvilGiraf/Controller/DeploymentController.cs
@@ -8,10 +8,10 @@ namespace EvilGiraf.Controller;
 
 [Authorize]
 [ApiController]
-[Route("")]
+[Route("deploy")]
 public class DeploymentController(IDeploymentService deploymentService, IApplicationService applicationService, IKubernetesService kubernetesService) : ControllerBase
 {
-    [HttpPost("application/{id:int}/deploy")]
+    [HttpPost("{id:int}")]
     [ProducesResponseType(201)]
     [ProducesResponseType(typeof(string), 404)]
     public async  Task<IActionResult> Deploy(int id)
@@ -22,10 +22,10 @@ public class DeploymentController(IDeploymentService deploymentService, IApplica
         
         _ = kubernetesService.Deploy(app);
         
-        return Created($"application/{id:int}/deploy", null);
+        return Created($"deploy/{id:int}", null);
     }
     
-    [HttpGet("application/{id:int}/deploy")]
+    [HttpGet("{id:int}")]
     [ProducesResponseType(typeof(DeployResponse), 200)]
     [ProducesResponseType(typeof(string), 404)]
     public async  Task<IActionResult> Status(int id)


### PR DESCRIPTION
Updated deployment endpoints to use a more concise route format. Replaced `/application/{id}/deploy` with `/deploy/{id}` for both POST and GET methods, ensuring consistency across the API. Adjusted integration tests accordingly to align with the new routes.