### PR TITLE
97 container port config

### DIFF
--- a/EvilGiraf.IntegrationTests/ApplicationControllerTests.cs
+++ b/EvilGiraf.IntegrationTests/ApplicationControllerTests.cs
@@ -21,7 +21,7 @@ public class ApplicationControllerTests : AuthenticatedTestBase
     public async Task Create_ShouldCreateApplication()
     {
         // Arrange
-        var createRequest = new ApplicationCreateDto("test-application", ApplicationType.Docker, "docker.io/test-application:latest", "1.0.0");
+        var createRequest = new ApplicationCreateDto("test-application", ApplicationType.Docker, "docker.io/test-application:latest", "1.0.0", [22]);
 
         // Act
         var response = await Client.PostAsJsonAsync("/application", createRequest);
@@ -36,6 +36,7 @@ public class ApplicationControllerTests : AuthenticatedTestBase
         application.Link.Should().Be(createRequest.Link);
         application.Version.Should().Be(createRequest.Version);
         application.Id.Should().NotBe(0);
+        application.Ports.Should().BeEquivalentTo(createRequest.Ports);
 
         // Verify the application was saved to the database
         var savedApplication = await _dbContext.Applications.FindAsync(application.Id);
@@ -44,13 +45,14 @@ public class ApplicationControllerTests : AuthenticatedTestBase
         savedApplication.Type.Should().Be(createRequest.Type);
         savedApplication.Link.Should().Be(createRequest.Link);
         savedApplication.Version.Should().Be(createRequest.Version);
+        savedApplication.Ports.Should().BeEquivalentTo(createRequest.Ports);
     }
 
     [Fact]
     public async Task CreateWithWrongBody_ShouldReturnBadRequest()
     {
         // Arrange
-        var createRequest = new ApplicationCreateDto(null!, ApplicationType.Docker, "docker.io/test-application:latest", "1.0.0");
+        var createRequest = new ApplicationCreateDto(null!, ApplicationType.Docker, "docker.io/test-application:latest", "1.0.0", [22]);
 
         // Act
         var response = await Client.PostAsJsonAsync("/application", createRequest);
@@ -68,7 +70,8 @@ public class ApplicationControllerTests : AuthenticatedTestBase
             Name = "test-application",
             Type = ApplicationType.Docker,
             Link = "docker.io/test-application:latest",
-            Version = "1.0.0"
+            Version = "1.0.0",
+            Ports = [22]
         };
 
         _dbContext.Applications.Add(application);
@@ -87,6 +90,7 @@ public class ApplicationControllerTests : AuthenticatedTestBase
         applicationDto.Link.Should().Be(application.Link);
         applicationDto.Version.Should().Be(application.Version);
         applicationDto.Id.Should().Be(application.Id);
+        applicationDto.Ports.Should().BeEquivalentTo(application.Ports);
     }
 
     [Fact]
@@ -98,7 +102,8 @@ public class ApplicationControllerTests : AuthenticatedTestBase
             Name = "test-application",
             Type = ApplicationType.Docker,
             Link = "docker.io/test-application:latest",
-            Version = "1.0.0"
+            Version = "1.0.0",
+            Ports = [22]
         };
 
         _dbContext.Applications.Add(application);
@@ -120,7 +125,8 @@ public class ApplicationControllerTests : AuthenticatedTestBase
             Name = "test-application",
             Type = ApplicationType.Docker,
             Link = "docker.io/test-application:latest",
-            Version = "1.0.0"
+            Version = "1.0.0",
+            Ports = [22]
         };
 
         _dbContext.Applications.Add(application);
@@ -155,13 +161,14 @@ public class ApplicationControllerTests : AuthenticatedTestBase
             Name = "test-application",
             Type = ApplicationType.Docker,
             Link = "docker.io/test-application:latest",
-            Version = "1.0.0"
+            Version = "1.0.0",
+            Ports = [22]
         };
 
         _dbContext.Applications.Add(application);
         await _dbContext.SaveChangesAsync();
 
-        var updateRequest = new ApplicationUpdateDto("updated-application", ApplicationType.Git, "k8s.io/updated-application:latest", "2.0.0");
+        var updateRequest = new ApplicationUpdateDto("updated-application", ApplicationType.Git, "k8s.io/updated-application:latest", "2.0.0", [23]);
 
         // Act
         var response = await Client.PatchAsJsonAsync($"/application/{application.Id}", updateRequest);
@@ -177,6 +184,7 @@ public class ApplicationControllerTests : AuthenticatedTestBase
         updatedApplication.Link.Should().Be(updateRequest.Link);
         updatedApplication.Version.Should().Be(updateRequest.Version);
         updatedApplication.Id.Should().Be(application.Id);
+        updatedApplication.Ports.Should().BeEquivalentTo(updateRequest.Ports);
 
         // Verify the application was updated in the database
         response = await Client.GetAsync($"/application/{application.Id}");
@@ -188,13 +196,14 @@ public class ApplicationControllerTests : AuthenticatedTestBase
         savedApplication.Type.Should().Be(updateRequest.Type);
         savedApplication.Link.Should().Be(updateRequest.Link);
         savedApplication.Version.Should().Be(updateRequest.Version);
+        savedApplication.Ports.Should().BeEquivalentTo(updateRequest.Ports);
     }
 
     [Fact]
     public async Task UpdateWithNonExistingId_ShouldReturnNotFound()
     {
         // Arrange
-        var updateRequest = new ApplicationUpdateDto("updated-application", ApplicationType.Git, "k8s.io/updated-application:latest", "2.0.0");
+        var updateRequest = new ApplicationUpdateDto("updated-application", ApplicationType.Git, "k8s.io/updated-application:latest", "2.0.0", [22]);
 
         // Act
         var response = await Client.PatchAsJsonAsync($"/application/{999}", updateRequest);
@@ -212,13 +221,14 @@ public class ApplicationControllerTests : AuthenticatedTestBase
             Name = "test-application",
             Type = ApplicationType.Docker,
             Link = "docker.io/test-application:latest",
-            Version = "1.0.0"
+            Version = "1.0.0",
+            Ports = [22]
         };
 
         _dbContext.Applications.Add(application);
         await _dbContext.SaveChangesAsync();
 
-        var updateRequest = new ApplicationUpdateDto(null, null, null, null);
+        var updateRequest = new ApplicationUpdateDto(null, null, null, null, null);
 
         // Act
         var response = await Client.PatchAsJsonAsync($"/application/{application.Id}", updateRequest);
@@ -234,6 +244,7 @@ public class ApplicationControllerTests : AuthenticatedTestBase
         updatedApplication.Link.Should().Be(application.Link);
         updatedApplication.Version.Should().Be(application.Version);
         updatedApplication.Id.Should().Be(application.Id);
+        updatedApplication.Ports.Should().BeEquivalentTo(application.Ports);
 
         // Verify the application was updated in the database
         response = await Client.GetAsync($"/application/{application.Id}");
@@ -245,6 +256,7 @@ public class ApplicationControllerTests : AuthenticatedTestBase
         savedApplication.Type.Should().Be(application.Type);
         savedApplication.Link.Should().Be(application.Link);
         savedApplication.Version.Should().Be(application.Version);
+        savedApplication.Ports.Should().BeEquivalentTo(application.Ports);
     }
 
     [Fact]
@@ -262,14 +274,16 @@ public class ApplicationControllerTests : AuthenticatedTestBase
                 Name = "test-application-1",
                 Type = ApplicationType.Docker,
                 Link = "docker.io/test-application-1:latest",
-                Version = "1.0.0"
+                Version = "1.0.0",
+                Ports = [22]
             },
             new()
             {
                 Name = "test-application-2",
                 Type = ApplicationType.Git,
                 Link = "k8s.io/test-application-2:latest",
-                Version = "2.0.0"
+                Version = "2.0.0",
+                Ports = [22]
             }
         };
 
@@ -291,12 +305,14 @@ public class ApplicationControllerTests : AuthenticatedTestBase
         applicationDtos[0].Link.Should().Be(applications[0].Link);
         applicationDtos[0].Version.Should().Be(applications[0].Version);
         applicationDtos[0].Id.Should().Be(applications[0].Id);
+        applicationDtos[0].Ports.Should().BeEquivalentTo(applications[0].Ports);
 
         applicationDtos[1].Name.Should().Be(applications[1].Name);
         applicationDtos[1].Type.Should().Be(applications[1].Type);
         applicationDtos[1].Link.Should().Be(applications[1].Link);
         applicationDtos[1].Version.Should().Be(applications[1].Version);
         applicationDtos[1].Id.Should().Be(applications[1].Id);
+        applicationDtos[1].Ports.Should().BeEquivalentTo(applications[1].Ports);
     }
 
     [Fact]

--- a/EvilGiraf.IntegrationTests/ApplicationControllerTests.cs
+++ b/EvilGiraf.IntegrationTests/ApplicationControllerTests.cs
@@ -338,7 +338,7 @@ public class ApplicationControllerTests : AuthenticatedTestBase
     public async Task CreateWithNoPorts_ShouldReturnApplication()
     {
         // Arrange
-        var createRequest = new ApplicationCreateDto("test-application", ApplicationType.Docker, "docker.io/test-application:latest", "1.0.0", []);
+        var createRequest = new ApplicationCreateDto("test-application", ApplicationType.Docker, "docker.io/test-application:latest", "1.0.0", null);
 
         // Act
         var response = await Client.PostAsJsonAsync("/application", createRequest);

--- a/EvilGiraf.IntegrationTests/DeploymentControllerTests.cs
+++ b/EvilGiraf.IntegrationTests/DeploymentControllerTests.cs
@@ -32,7 +32,8 @@ public class DeploymentControllerTests : AuthenticatedTestBase
             Name = "test-app",
             Type = ApplicationType.Docker,
             Link = "docker.io/test-app:latest",
-            Version = "1.0.0"
+            Version = "1.0.0",
+            Ports = [22]
         };
         var deployment = new HttpOperationResponse<V1Deployment>
         {
@@ -85,7 +86,8 @@ public class DeploymentControllerTests : AuthenticatedTestBase
             Name = "test-app",
             Type = ApplicationType.Docker,
             Link = "docker.io/test-app:latest",
-            Version = "1.0.0"
+            Version = "1.0.0",
+            Ports = [22]
         };
 
         var deployment = new HttpOperationResponse<V1Deployment>
@@ -151,7 +153,8 @@ public class DeploymentControllerTests : AuthenticatedTestBase
             Name = "test-app",
             Type = ApplicationType.Docker,
             Link = "docker.io/test-app:latest",
-            Version = "1.0.0"
+            Version = "1.0.0",
+            Ports = [22]
         };
 
         var deployment = new HttpOperationResponse<V1Deployment>
@@ -193,7 +196,8 @@ public class DeploymentControllerTests : AuthenticatedTestBase
             Name = "test-app",
             Type = ApplicationType.Docker,
             Link = "docker.io/test-app:latest",
-            Version = "1.0.0"
+            Version = "1.0.0",
+            Ports = [22]
         };
         
         var httpException = new HttpOperationException

--- a/EvilGiraf.Tests/ApplicationServiceTests.cs
+++ b/EvilGiraf.Tests/ApplicationServiceTests.cs
@@ -20,7 +20,7 @@ public class ApplicationServiceTests
     public async Task CreateApplication_ShouldCreateAndReturnNewApplication()
     {
         // Arrange
-        var application = new ApplicationCreateDto("TestApp", ApplicationType.Docker, "https://test.com", "1.0.0");
+        var application = new ApplicationCreateDto("TestApp", ApplicationType.Docker, "https://test.com", "1.0.0", [22]);
 
         // Act
         var result = await _applicationService.CreateApplication(application);
@@ -31,13 +31,14 @@ public class ApplicationServiceTests
         result.Type.Should().Be(application.Type);
         result.Link.Should().Be(application.Link);
         result.Version.Should().Be(application.Version);
+        result.Ports.Should().BeEquivalentTo(application.Ports);
     }
 
     [Fact]
     public async Task GetApplication_ShouldReturnApplication()
     {
         // Arrange
-        var application = new ApplicationCreateDto("TestApp", ApplicationType.Docker, "https://test.com", "1.0.0");
+        var application = new ApplicationCreateDto("TestApp", ApplicationType.Docker, "https://test.com", "1.0.0", [22]);
         var createdApplication = await _applicationService.CreateApplication(application);
 
         // Act
@@ -50,6 +51,7 @@ public class ApplicationServiceTests
         result.Type.Should().Be(application.Type);
         result.Link.Should().Be(application.Link);
         result.Version.Should().Be(application.Version);
+        result.Ports.Should().BeEquivalentTo(application.Ports);
     }
 
     [Fact]
@@ -66,7 +68,7 @@ public class ApplicationServiceTests
     public async Task DeleteApplication_ShouldDeleteApplication()
     {
         // Arrange
-        var application = new ApplicationCreateDto("TestApp", ApplicationType.Docker, "https://test.com", "1.0.0");
+        var application = new ApplicationCreateDto("TestApp", ApplicationType.Docker, "https://test.com", "1.0.0", [22]);
         var createdApplication = await _applicationService.CreateApplication(application);
 
         // Act
@@ -94,11 +96,11 @@ public class ApplicationServiceTests
     {
         // Arrange
         var applicationDto = new ApplicationCreateDto(
-            "TestApp", ApplicationType.Docker, "https://test.com", "1.0.0");
+            "TestApp", ApplicationType.Docker, "https://test.com", "1.0.0", [22]);
         var createdApplication = await _applicationService.CreateApplication(applicationDto);
 
         var updatedApplicationDto = new ApplicationUpdateDto(
-            "UpdatedTestApp", ApplicationType.Docker, "https://updatedtest.com", "2.0.0");
+            "UpdatedTestApp", ApplicationType.Docker, "https://updatedtest.com", "2.0.0", [23]);
 
         // Act
         var result = await _applicationService.UpdateApplication(createdApplication.Id, updatedApplicationDto);
@@ -110,6 +112,7 @@ public class ApplicationServiceTests
         result.Type.Should().Be(updatedApplicationDto.Type);
         result.Link.Should().Be(updatedApplicationDto.Link);
         result.Version.Should().Be(updatedApplicationDto.Version);
+        result.Ports.Should().BeEquivalentTo(updatedApplicationDto.Ports);
     }
     
     [Fact]
@@ -117,11 +120,11 @@ public class ApplicationServiceTests
     {
         // Arrange
         var applicationDto = new ApplicationCreateDto(
-            "TestApp", ApplicationType.Docker, "https://test.com", "1.0.0");
+            "TestApp", ApplicationType.Docker, "https://test.com", "1.0.0", [22]);
         var createdApplication = await _applicationService.CreateApplication(applicationDto);
 
         var updatedApplicationDto = new ApplicationUpdateDto(
-            null, null, null, null);
+            null, null, null, null, null);
 
         // Act
         var result = await _applicationService.UpdateApplication(createdApplication.Id, updatedApplicationDto);
@@ -133,6 +136,7 @@ public class ApplicationServiceTests
         result.Type.Should().Be(applicationDto.Type);
         result.Link.Should().Be(applicationDto.Link);
         result.Version.Should().Be(applicationDto.Version);
+        result.Ports.Should().BeEquivalentTo(applicationDto.Ports);
     }
     
     [Fact]
@@ -140,7 +144,7 @@ public class ApplicationServiceTests
     {
         // Arrange
         var updatedApplicationDto = new ApplicationUpdateDto(
-            "UpdatedTestApp", ApplicationType.Docker, "https://updatedtest.com", "2.0.0");
+            "UpdatedTestApp", ApplicationType.Docker, "https://updatedtest.com", "2.0.0", [22]);
 
         // Act
         var result = await _applicationService.UpdateApplication(999, updatedApplicationDto);
@@ -159,9 +163,9 @@ public class ApplicationServiceTests
             await _applicationService.DeleteApplication(app.Id);
         }
 
-        var application1 = new ApplicationCreateDto("TestApp1", ApplicationType.Docker, "https://test.com", "1.0.0");
-        var application2 = new ApplicationCreateDto("TestApp2", ApplicationType.Docker, "https://test.com", "1.0.0");
-        var application3 = new ApplicationCreateDto("TestApp3", ApplicationType.Docker, "https://test.com", "1.0.0");
+        var application1 = new ApplicationCreateDto("TestApp1", ApplicationType.Docker, "https://test.com", "1.0.0", [22]);
+        var application2 = new ApplicationCreateDto("TestApp2", ApplicationType.Docker, "https://test.com", "1.0.0", [22]);
+        var application3 = new ApplicationCreateDto("TestApp3", ApplicationType.Docker, "https://test.com", "1.0.0", [22]);
 
         await _applicationService.CreateApplication(application1);
         await _applicationService.CreateApplication(application2);

--- a/EvilGiraf.Tests/KubernetesTests.cs
+++ b/EvilGiraf.Tests/KubernetesTests.cs
@@ -25,7 +25,8 @@ public class KubernetesTests
         Name = "test-app",
         Type = ApplicationType.Docker,
         Link = "docker.io/test:latest",
-        Version = "1.0.0"
+        Version = "1.0.0",
+        Ports = [22]
     };
 
     [Fact]

--- a/EvilGiraf/Dto/ApplicationDto.cs
+++ b/EvilGiraf/Dto/ApplicationDto.cs
@@ -7,7 +7,7 @@ public record ApplicationCreateDto(
     ApplicationType Type,
     string Link,
     string? Version,
-    int[] Ports
+    int[]? Ports
 );
 
 public record ApplicationResultDto(

--- a/EvilGiraf/Dto/ApplicationDto.cs
+++ b/EvilGiraf/Dto/ApplicationDto.cs
@@ -7,7 +7,7 @@ public record ApplicationCreateDto(
     ApplicationType Type,
     string Link,
     string? Version,
-    int[]? Ports
+    int[] Ports
 );
 
 public record ApplicationResultDto(
@@ -16,7 +16,7 @@ public record ApplicationResultDto(
     ApplicationType Type,
     string Link,
     string? Version,
-    int[]? Ports
+    int[] Ports
 );
 
 public record ApplicationUpdateDto(

--- a/EvilGiraf/Dto/ApplicationDto.cs
+++ b/EvilGiraf/Dto/ApplicationDto.cs
@@ -6,7 +6,8 @@ public record ApplicationCreateDto(
     string Name,
     ApplicationType Type,
     string Link,
-    string? Version
+    string? Version,
+    int[]? Ports
 );
 
 public record ApplicationResultDto(
@@ -14,12 +15,14 @@ public record ApplicationResultDto(
     string Name,
     ApplicationType Type,
     string Link,
-    string? Version
+    string? Version,
+    int[]? Ports
 );
 
 public record ApplicationUpdateDto(
     string? Name,
     ApplicationType? Type,
     string? Link,
-    string? Version
+    string? Version,
+    int[]? Ports
 );

--- a/EvilGiraf/Extensions/ApplicationExtensions.cs
+++ b/EvilGiraf/Extensions/ApplicationExtensions.cs
@@ -1,6 +1,5 @@
 using EvilGiraf.Model;
 using EvilGiraf.Dto;
-using Npgsql.Replication;
 
 namespace EvilGiraf.Extensions;
 

--- a/EvilGiraf/Extensions/ApplicationExtensions.cs
+++ b/EvilGiraf/Extensions/ApplicationExtensions.cs
@@ -1,5 +1,6 @@
 using EvilGiraf.Model;
 using EvilGiraf.Dto;
+using Npgsql.Replication;
 
 namespace EvilGiraf.Extensions;
 
@@ -25,7 +26,7 @@ public static class ApplicationExtensions
             Type = applicationDto.Type,
             Link = applicationDto.Link,
             Version = applicationDto.Version,
-            Ports = applicationDto.Ports
+            Ports = applicationDto.Ports is not null ? applicationDto.Ports : Array.Empty<int>()
         };
     }
 }

--- a/EvilGiraf/Extensions/ApplicationExtensions.cs
+++ b/EvilGiraf/Extensions/ApplicationExtensions.cs
@@ -12,7 +12,8 @@ public static class ApplicationExtensions
             application.Name,
             application.Type,
             application.Link,
-            application.Version
+            application.Version,
+            application.Ports
         );
     }
 
@@ -23,7 +24,8 @@ public static class ApplicationExtensions
             Name = applicationDto.Name,
             Type = applicationDto.Type,
             Link = applicationDto.Link,
-            Version = applicationDto.Version
+            Version = applicationDto.Version,
+            Ports = applicationDto.Ports
         };
     }
 }

--- a/EvilGiraf/Migrations/20250206162202_InitialCreate.Designer.cs
+++ b/EvilGiraf/Migrations/20250206162202_InitialCreate.Designer.cs
@@ -47,6 +47,7 @@ namespace EvilGiraf.Migrations
                         .HasColumnType("text");
 
                     b.Property<int[]>("Ports")
+                        .IsRequired()
                         .HasColumnType("integer[]");
 
                     b.HasKey("Id");

--- a/EvilGiraf/Migrations/20250206162202_InitialCreate.Designer.cs
+++ b/EvilGiraf/Migrations/20250206162202_InitialCreate.Designer.cs
@@ -46,6 +46,9 @@ namespace EvilGiraf.Migrations
                     b.Property<string>("Version")
                         .HasColumnType("text");
 
+                    b.Property<int[]>("Ports")
+                        .HasColumnType("integer[]");
+
                     b.HasKey("Id");
 
                     b.ToTable("Applications");

--- a/EvilGiraf/Migrations/20250206162202_InitialCreate.cs
+++ b/EvilGiraf/Migrations/20250206162202_InitialCreate.cs
@@ -23,7 +23,7 @@ namespace EvilGiraf.Migrations
                     Type = table.Column<int>(type: "integer", nullable: false),
                     Link = table.Column<string>(type: "text", nullable: false),
                     Version = table.Column<string>(type: "text", nullable: true),
-                    Ports = table.Column<int[]>(type: "integer[]", nullable: true)
+                    Ports = table.Column<int[]>(type: "integer[]", nullable: false)
                 },
                 constraints: table =>
                 {

--- a/EvilGiraf/Migrations/20250206162202_InitialCreate.cs
+++ b/EvilGiraf/Migrations/20250206162202_InitialCreate.cs
@@ -22,7 +22,8 @@ namespace EvilGiraf.Migrations
                     Name = table.Column<string>(type: "text", nullable: false),
                     Type = table.Column<int>(type: "integer", nullable: false),
                     Link = table.Column<string>(type: "text", nullable: false),
-                    Version = table.Column<string>(type: "text", nullable: true)
+                    Version = table.Column<string>(type: "text", nullable: true),
+                    Ports = table.Column<int[]>(type: "integer[]", nullable: true)
                 },
                 constraints: table =>
                 {

--- a/EvilGiraf/Migrations/DatabaseServiceModelSnapshot.cs
+++ b/EvilGiraf/Migrations/DatabaseServiceModelSnapshot.cs
@@ -47,6 +47,7 @@ namespace EvilGiraf.Migrations
                         .HasColumnType("character varying(255)");
 
                     b.Property<int[]>("Ports")
+                        .IsRequired()
                         .HasColumnType("integer[]");
 
                     b.HasKey("Id");

--- a/EvilGiraf/Migrations/DatabaseServiceModelSnapshot.cs
+++ b/EvilGiraf/Migrations/DatabaseServiceModelSnapshot.cs
@@ -46,6 +46,9 @@ namespace EvilGiraf.Migrations
                         .HasMaxLength(255)
                         .HasColumnType("character varying(255)");
 
+                    b.Property<int[]>("Ports")
+                        .HasColumnType("integer[]");
+
                     b.HasKey("Id");
 
                     b.ToTable("Applications");

--- a/EvilGiraf/Model/Application.cs
+++ b/EvilGiraf/Model/Application.cs
@@ -19,4 +19,6 @@ public class Application
     
     [MaxLength(255)]
     public string? Version { get; set; }
+
+    public int[]? Ports { get; set; }
 }

--- a/EvilGiraf/Model/Application.cs
+++ b/EvilGiraf/Model/Application.cs
@@ -20,5 +20,5 @@ public class Application
     [MaxLength(255)]
     public string? Version { get; set; }
 
-    public int[]? Ports { get; set; }
+    public required int[] Ports { get; set; }
 }

--- a/EvilGiraf/Service/ApplicationService.cs
+++ b/EvilGiraf/Service/ApplicationService.cs
@@ -45,6 +45,8 @@ public class ApplicationService(DatabaseService databaseService) : IApplicationS
             application.Link = applicationUpdateDto.Link;
         if (applicationUpdateDto.Version is not null)
             application.Version = applicationUpdateDto.Version;
+        if (applicationUpdateDto.Ports is not null)
+            application.Ports = applicationUpdateDto.Ports;
         var updatedApp = databaseService.Applications.Update(application).Entity;
         await databaseService.SaveChangesAsync();
         return updatedApp;

--- a/EvilGiraf/Service/ApplicationService.cs
+++ b/EvilGiraf/Service/ApplicationService.cs
@@ -47,6 +47,7 @@ public class ApplicationService(DatabaseService databaseService) : IApplicationS
             application.Version = applicationUpdateDto.Version;
         if (applicationUpdateDto.Ports is not null)
             application.Ports = applicationUpdateDto.Ports;
+
         var updatedApp = databaseService.Applications.Update(application).Entity;
         await databaseService.SaveChangesAsync();
         return updatedApp;


### PR DESCRIPTION
This pull request includes several changes to the integration and unit tests for the `ApplicationController` and `DeploymentController` classes. The main update is the addition of a new `Ports` property to the `ApplicationCreateDto` and `ApplicationUpdateDto` classes, which is now included in various test methods to ensure proper handling of this new property.

### Integration Tests Updates:
* Added `Ports` property to test cases in `EvilGiraf.IntegrationTests/ApplicationControllerTests.cs` to verify creation, retrieval, updating, and deletion of applications, ensuring the `Ports` property is correctly handled. [[1]](diffhunk://#diff-d41f11456c621976336f13cf3d5fd3b37b8b6fa73ae592bb6cb9e2c180b36a1bL24-R24) [[2]](diffhunk://#diff-d41f11456c621976336f13cf3d5fd3b37b8b6fa73ae592bb6cb9e2c180b36a1bR39) [[3]](diffhunk://#diff-d41f11456c621976336f13cf3d5fd3b37b8b6fa73ae592bb6cb9e2c180b36a1bR48-R55) [[4]](diffhunk://#diff-d41f11456c621976336f13cf3d5fd3b37b8b6fa73ae592bb6cb9e2c180b36a1bL71-R74) [[5]](diffhunk://#diff-d41f11456c621976336f13cf3d5fd3b37b8b6fa73ae592bb6cb9e2c180b36a1bR93) [[6]](diffhunk://#diff-d41f11456c621976336f13cf3d5fd3b37b8b6fa73ae592bb6cb9e2c180b36a1bL101-R106) [[7]](diffhunk://#diff-d41f11456c621976336f13cf3d5fd3b37b8b6fa73ae592bb6cb9e2c180b36a1bL123-R129) [[8]](diffhunk://#diff-d41f11456c621976336f13cf3d5fd3b37b8b6fa73ae592bb6cb9e2c180b36a1bL158-R171) [[9]](diffhunk://#diff-d41f11456c621976336f13cf3d5fd3b37b8b6fa73ae592bb6cb9e2c180b36a1bR187) [[10]](diffhunk://#diff-d41f11456c621976336f13cf3d5fd3b37b8b6fa73ae592bb6cb9e2c180b36a1bR199-R206) [[11]](diffhunk://#diff-d41f11456c621976336f13cf3d5fd3b37b8b6fa73ae592bb6cb9e2c180b36a1bL215-R231) [[12]](diffhunk://#diff-d41f11456c621976336f13cf3d5fd3b37b8b6fa73ae592bb6cb9e2c180b36a1bR247) [[13]](diffhunk://#diff-d41f11456c621976336f13cf3d5fd3b37b8b6fa73ae592bb6cb9e2c180b36a1bR259) [[14]](diffhunk://#diff-d41f11456c621976336f13cf3d5fd3b37b8b6fa73ae592bb6cb9e2c180b36a1bL265-R286) [[15]](diffhunk://#diff-d41f11456c621976336f13cf3d5fd3b37b8b6fa73ae592bb6cb9e2c180b36a1bR308-R315)
* Updated `DeploymentControllerTests.cs` to include the `Ports` property in deployment-related test cases. [[1]](diffhunk://#diff-2b8550fdb2e5c7611e33b2349f1c866a5f3e921d835d042a1e493d32ee5d4e6fL35-R36) [[2]](diffhunk://#diff-2b8550fdb2e5c7611e33b2349f1c866a5f3e921d835d042a1e493d32ee5d4e6fL88-R90) [[3]](diffhunk://#diff-2b8550fdb2e5c7611e33b2349f1c866a5f3e921d835d042a1e493d32ee5d4e6fL154-R157) [[4]](diffhunk://#diff-2b8550fdb2e5c7611e33b2349f1c866a5f3e921d835d042a1e493d32ee5d4e6fL196-R200)

### Unit Tests Updates:
* Modified `EvilGiraf.Tests/ApplicationServiceTests.cs` to include the `Ports` property in application creation and update test cases, ensuring the service layer correctly processes this new property. [[1]](diffhunk://#diff-c0d5bc04e94f35b81dc2cb41eed915b587d3e22b454584f9e8c1af60dfb74146L23-R23) [[2]](diffhunk://#diff-c0d5bc04e94f35b81dc2cb41eed915b587d3e22b454584f9e8c1af60dfb74146R34-R41) [[3]](diffhunk://#diff-c0d5bc04e94f35b81dc2cb41eed915b587d3e22b454584f9e8c1af60dfb74146R54) [[4]](diffhunk://#diff-c0d5bc04e94f35b81dc2cb41eed915b587d3e22b454584f9e8c1af60dfb74146L69-R71) [[5]](diffhunk://#diff-c0d5bc04e94f35b81dc2cb41eed915b587d3e22b454584f9e8c1af60dfb74146L97-R103) [[6]](diffhunk://#diff-c0d5bc04e94f35b81dc2cb41eed915b587d3e22b454584f9e8c1af60dfb74146R115-R127) [[7]](diffhunk://#diff-c0d5bc04e94f35b81dc2cb41eed915b587d3e22b454584f9e8c1af60dfb74146R139-R147) [[8]](diffhunk://#diff-c0d5bc04e94f35b81dc2cb41eed915b587d3e22b454584f9e8c1af60dfb74146L162-R168)

closes #97 