### PR TITLE
refactor: update status code for non-deployed application check

### DIFF
--- a/EvilGiraf.IntegrationTests/DeploymentControllerTests.cs
+++ b/EvilGiraf.IntegrationTests/DeploymentControllerTests.cs
@@ -185,7 +185,7 @@ public class DeploymentControllerTests : AuthenticatedTestBase
     }
 
     [Fact]
-    public async Task Status_ShouldReturn404_WhenApplicationExistsButNotDeployed()
+    public async Task Status_ShouldReturn201_WhenApplicationExistsButNotDeployed()
     {
         // Arrange
         var application = new Application
@@ -213,9 +213,7 @@ public class DeploymentControllerTests : AuthenticatedTestBase
         var response = await Client.GetAsync($"/deploy/{application.Id}");
 
         // Assert
-        response.Should().HaveStatusCode(HttpStatusCode.NotFound);
-        var error = await response.Content.ReadAsStringAsync();
-        error.Should().Contain($"Application {application.Id} is not deployed");
+        response.Should().HaveStatusCode(HttpStatusCode.NoContent);
     }
 
     [Fact]

--- a/EvilGiraf/Controller/DeploymentController.cs
+++ b/EvilGiraf/Controller/DeploymentController.cs
@@ -36,7 +36,7 @@ public class DeploymentController(IDeploymentService deploymentService, IApplica
 
         var deployment = await deploymentService.ReadDeployment(app.Name, app.Id.ToNamespace());
         if (deployment is null)
-            return NotFound($"Application {id} is not deployed");
+            return NoContent();
         
         return Ok(new DeployResponse(deployment.Status));
     }


### PR DESCRIPTION
Adjusted the status code to return 204 No Content instead of 404 Not Found when an application exists but is not deployed. This aligns the response with expected standards and avoids misleading error handling.

Closes #117 