### PR TITLE
chore: add 204 response type to Status endpoint

### DIFF
--- a/EvilGiraf/Controller/DeploymentController.cs
+++ b/EvilGiraf/Controller/DeploymentController.cs
@@ -27,6 +27,7 @@ public class DeploymentController(IDeploymentService deploymentService, IApplica
     
     [HttpGet("{id:int}")]
     [ProducesResponseType(typeof(DeployResponse), 200)]
+    [ProducesResponseType(204)]
     [ProducesResponseType(typeof(string), 404)]
     public async  Task<IActionResult> Status(int id)
     {


### PR DESCRIPTION
Added a 204 response type to indicate no content when applicable for the Status endpoint in DeploymentController. This improves API response clarity and aligns with REST standards.