### PR TITLE
feat: add JSON string enum converter to ApplicationType

### DIFF
--- a/EvilGiraf/Model/ApplicationType.cs
+++ b/EvilGiraf/Model/ApplicationType.cs
@@ -1,5 +1,8 @@
+using System.Text.Json.Serialization;
+
 namespace EvilGiraf.Model;
 
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum ApplicationType
 {
     Docker,


### PR DESCRIPTION
Added a JsonStringEnumConverter to the ApplicationType enum to enable JSON serialization and deserialization using string values instead of numerical indices. This improves clarity and interoperability when exchanging data in JSON format.

Closes #121 