### PR TITLE
refactor: update API routes to include '/api' prefix

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -225,21 +225,6 @@ jobs:
         with:
           useConfigFile: true
 
-      - name: Cache SonarQube packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.sonar/cache
-          key: ${{ runner.os }}-sonar
-          restore-keys: ${{ runner.os }}-sonar
-
-      - name: Cache SonarQube scanner
-        id: cache-sonar-scanner
-        uses: actions/cache@v4
-        with:
-          path: ./.sonar/scanner
-          key: ${{ runner.os }}-sonar-scanner
-          restore-keys: ${{ runner.os }}-sonar-scanner
-
       - name: Install SonarQube scanner
         if: steps.cache-sonar-scanner.outputs.cache-hit != 'true'
         run: |

--- a/EvilGiraf.Front/.env
+++ b/EvilGiraf.Front/.env
@@ -1,1 +1,1 @@
-VITE_API_URL=
+VITE_API_URL=/api

--- a/EvilGiraf.Front/src/lib/api.ts
+++ b/EvilGiraf.Front/src/lib/api.ts
@@ -2,7 +2,7 @@ import { ApplicationCreateDto, ApplicationResultDto, DeployResponse } from '../t
 import Cookies from 'js-cookie';
 
 const API_URL = import.meta.env.DEV
-  ? '/api'
+  ? '/dev'
   : import.meta.env.VITE_API_URL;
 
 function getHeaders() {

--- a/EvilGiraf.Front/vite.config.ts
+++ b/EvilGiraf.Front/vite.config.ts
@@ -9,10 +9,10 @@ export default defineConfig({
   },
   server: {
     proxy: {
-      '/api': {
+      '/dev': {
         target: 'http://localhost:5255',
         changeOrigin: true,
-        rewrite: (path) => path.replace(/^\/api/, ''),
+        rewrite: (path) => path.replace(/^\/dev/, ''),
       },
     },
   },

--- a/EvilGiraf.IntegrationTests/ApplicationControllerTests.cs
+++ b/EvilGiraf.IntegrationTests/ApplicationControllerTests.cs
@@ -24,7 +24,7 @@ public class ApplicationControllerTests : AuthenticatedTestBase
         var createRequest = new ApplicationCreateDto("test-application", ApplicationType.Docker, "docker.io/test-application:latest", "1.0.0", [22]);
 
         // Act
-        var response = await Client.PostAsJsonAsync("/application", createRequest);
+        var response = await Client.PostAsJsonAsync("/api/application", createRequest);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Created);
@@ -55,7 +55,7 @@ public class ApplicationControllerTests : AuthenticatedTestBase
         var createRequest = new ApplicationCreateDto(null!, ApplicationType.Docker, "docker.io/test-application:latest", "1.0.0", [22]);
 
         // Act
-        var response = await Client.PostAsJsonAsync("/application", createRequest);
+        var response = await Client.PostAsJsonAsync("/api/application", createRequest);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
@@ -78,7 +78,7 @@ public class ApplicationControllerTests : AuthenticatedTestBase
         await _dbContext.SaveChangesAsync();
 
         // Act
-        var response = await Client.GetAsync($"/application/{application.Id}");
+        var response = await Client.GetAsync($"/api/application/{application.Id}");
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -110,7 +110,7 @@ public class ApplicationControllerTests : AuthenticatedTestBase
         await _dbContext.SaveChangesAsync();
 
         // Act
-        var response = await Client.GetAsync($"/application/{application.Id + 1}");
+        var response = await Client.GetAsync($"/api/application/{application.Id + 1}");
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
@@ -133,12 +133,12 @@ public class ApplicationControllerTests : AuthenticatedTestBase
         await _dbContext.SaveChangesAsync();
 
         // Act
-        var response = await Client.DeleteAsync($"/application/{application.Id}");
+        var response = await Client.DeleteAsync($"/api/application/{application.Id}");
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.NoContent);
 
-        var checkresponse = await Client.GetAsync($"/application/{application.Id}");
+        var checkresponse = await Client.GetAsync($"/api/application/{application.Id}");
         checkresponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
 
@@ -146,7 +146,7 @@ public class ApplicationControllerTests : AuthenticatedTestBase
     public async Task DeleteWithNonExistingId_ShouldReturnNotFound()
     {
         // Act
-        var response = await Client.DeleteAsync($"/application/{999}");
+        var response = await Client.DeleteAsync($"/api/application/{999}");
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
@@ -171,7 +171,7 @@ public class ApplicationControllerTests : AuthenticatedTestBase
         var updateRequest = new ApplicationUpdateDto("updated-application", ApplicationType.Git, "k8s.io/updated-application:latest", "2.0.0", [23]);
 
         // Act
-        var response = await Client.PatchAsJsonAsync($"/application/{application.Id}", updateRequest);
+        var response = await Client.PatchAsJsonAsync($"/api/application/{application.Id}", updateRequest);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -187,7 +187,7 @@ public class ApplicationControllerTests : AuthenticatedTestBase
         updatedApplication.Ports.Should().BeEquivalentTo(updateRequest.Ports);
 
         // Verify the application was updated in the database
-        response = await Client.GetAsync($"/application/{application.Id}");
+        response = await Client.GetAsync($"/api/application/{application.Id}");
         var savedApplication = await response.Content.ReadFromJsonAsync<Application>();
 
         savedApplication.Should().NotBeNull();
@@ -206,7 +206,7 @@ public class ApplicationControllerTests : AuthenticatedTestBase
         var updateRequest = new ApplicationUpdateDto("updated-application", ApplicationType.Git, "k8s.io/updated-application:latest", "2.0.0", [22]);
 
         // Act
-        var response = await Client.PatchAsJsonAsync($"/application/{999}", updateRequest);
+        var response = await Client.PatchAsJsonAsync($"/api/application/{999}", updateRequest);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
@@ -231,7 +231,7 @@ public class ApplicationControllerTests : AuthenticatedTestBase
         var updateRequest = new ApplicationUpdateDto(null, null, null, null, null);
 
         // Act
-        var response = await Client.PatchAsJsonAsync($"/application/{application.Id}", updateRequest);
+        var response = await Client.PatchAsJsonAsync($"/api/application/{application.Id}", updateRequest);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -247,7 +247,7 @@ public class ApplicationControllerTests : AuthenticatedTestBase
         updatedApplication.Ports.Should().BeEquivalentTo(application.Ports);
 
         // Verify the application was updated in the database
-        response = await Client.GetAsync($"/application/{application.Id}");
+        response = await Client.GetAsync($"/api/application/{application.Id}");
         var savedApplication = await response.Content.ReadFromJsonAsync<Application>();
 
         savedApplication.Should().NotBeNull();
@@ -291,7 +291,7 @@ public class ApplicationControllerTests : AuthenticatedTestBase
         await _dbContext.SaveChangesAsync();
 
         // Act
-        var response = await Client.GetAsync("/application");
+        var response = await Client.GetAsync("/api/application");
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -324,7 +324,7 @@ public class ApplicationControllerTests : AuthenticatedTestBase
         await _dbContext.SaveChangesAsync();
         
         // Act
-        var response = await Client.GetAsync("/application");
+        var response = await Client.GetAsync("/api/application");
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -341,7 +341,7 @@ public class ApplicationControllerTests : AuthenticatedTestBase
         var createRequest = new ApplicationCreateDto("test-application", ApplicationType.Docker, "docker.io/test-application:latest", "1.0.0", null);
 
         // Act
-        var response = await Client.PostAsJsonAsync("/application", createRequest);
+        var response = await Client.PostAsJsonAsync("/api/application", createRequest);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Created);
@@ -372,7 +372,7 @@ public class ApplicationControllerTests : AuthenticatedTestBase
         var createRequest = new ApplicationCreateDto("test-application", ApplicationType.Docker, "docker.io/test-application:latest", "1.0.0", [22, 80]);
 
         // Act
-        var response = await Client.PostAsJsonAsync("/application", createRequest);
+        var response = await Client.PostAsJsonAsync("/api/application", createRequest);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Created);

--- a/EvilGiraf.IntegrationTests/AuthenticationTests.cs
+++ b/EvilGiraf.IntegrationTests/AuthenticationTests.cs
@@ -12,7 +12,7 @@ public class AuthenticationTests(CustomWebApplicationFactory factory) : Integrat
         using var client = Factory.CreateClient(); // Create new client without auth headers
 
         // Act
-        var response = await client.GetAsync("/application/1");
+        var response = await client.GetAsync("/api/application/1");
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
@@ -26,7 +26,7 @@ public class AuthenticationTests(CustomWebApplicationFactory factory) : Integrat
         client.DefaultRequestHeaders.Add("X-API-Key", "wrong-api-key");
 
         // Act
-        var response = await client.GetAsync("/application/1");
+        var response = await client.GetAsync("/api/application/1");
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
@@ -40,7 +40,7 @@ public class AuthenticationTests(CustomWebApplicationFactory factory) : Integrat
         client.DefaultRequestHeaders.Add("X-API-Key", ["", ""]); 
 
         // Act
-        var response = await client.GetAsync("/application/1");
+        var response = await client.GetAsync("/api/application/1");
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);

--- a/EvilGiraf.IntegrationTests/DeploymentControllerTests.cs
+++ b/EvilGiraf.IntegrationTests/DeploymentControllerTests.cs
@@ -63,7 +63,7 @@ public class DeploymentControllerTests : AuthenticatedTestBase
             .Returns(deployment);
 
         // Act
-        var response = await Client.PostAsync($"/deploy/{application.Id}", null);
+        var response = await Client.PostAsync($"/api/deploy/{application.Id}", null);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Created);
@@ -124,7 +124,7 @@ public class DeploymentControllerTests : AuthenticatedTestBase
         _kubernetes.CoreV1.ReadNamespaceWithHttpMessagesAsync(Arg.Any<string>()).Returns(new HttpOperationResponse<V1Namespace>());
         
         // Act
-        var response = await Client.PostAsync($"/deploy/{application.Id}", null);
+        var response = await Client.PostAsync($"/api/deploy/{application.Id}", null);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Created);
@@ -138,7 +138,7 @@ public class DeploymentControllerTests : AuthenticatedTestBase
     public async Task Deploy_ShouldReturn404_WhenApplicationDoesNotExist()
     {
         // Act
-        var response = await Client.PostAsync("/deploy/999", null);
+        var response = await Client.PostAsync("/api/deploy/999", null);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
@@ -179,7 +179,7 @@ public class DeploymentControllerTests : AuthenticatedTestBase
             .Returns(deployment);
 
         // Act
-        var response = await Client.GetAsync($"/deploy/{application.Id}");
+        var response = await Client.GetAsync($"/api/deploy/{application.Id}");
 
         // Assert
         response.Should().BeSuccessful();
@@ -215,7 +215,7 @@ public class DeploymentControllerTests : AuthenticatedTestBase
             .Throws(httpException);
 
         // Act
-        var response = await Client.GetAsync($"/deploy/{application.Id}");
+        var response = await Client.GetAsync($"/api/deploy/{application.Id}");
 
         // Assert
         response.Should().HaveStatusCode(HttpStatusCode.NoContent);
@@ -228,7 +228,7 @@ public class DeploymentControllerTests : AuthenticatedTestBase
         const int nonExistentApplicationId = 999;
 
         // Act
-        var response = await Client.GetAsync($"/deploy/{nonExistentApplicationId}");
+        var response = await Client.GetAsync($"/api/deploy/{nonExistentApplicationId}");
 
         // Assert
         response.Should().HaveStatusCode(HttpStatusCode.NotFound);
@@ -245,7 +245,7 @@ public class DeploymentControllerTests : AuthenticatedTestBase
         await _dbContext.SaveChangesAsync();
 
         // Act
-        var response = await Client.GetAsync("/deploy");
+        var response = await Client.GetAsync("/api/deploy");
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -274,7 +274,7 @@ public class DeploymentControllerTests : AuthenticatedTestBase
         _kubernetes.AppsV1.ReadNamespacedDeploymentWithHttpMessagesAsync(Arg.Any<string>(), Arg.Any<string>())
             .Returns(new HttpOperationResponse<V1Deployment>());
         // Act
-        var response = await Client.GetAsync("/deploy");
+        var response = await Client.GetAsync("/api/deploy");
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -309,7 +309,7 @@ public class DeploymentControllerTests : AuthenticatedTestBase
             .Returns(new HttpOperationResponse<V1Deployment> { Body = deployment });
 
         // Act
-        var response = await Client.GetAsync("/deploy");
+        var response = await Client.GetAsync("/api/deploy");
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);

--- a/EvilGiraf/Controller/ApplicationController.cs
+++ b/EvilGiraf/Controller/ApplicationController.cs
@@ -8,7 +8,7 @@ namespace EvilGiraf.Controller;
 
 [Authorize]
 [ApiController]
-[Route("application")]
+[Route("api/application")]
 public class ApplicationController(IApplicationService applicationService) : ControllerBase
 {
     [HttpPost("")]

--- a/EvilGiraf/Controller/DeploymentController.cs
+++ b/EvilGiraf/Controller/DeploymentController.cs
@@ -8,7 +8,7 @@ namespace EvilGiraf.Controller;
 
 [Authorize]
 [ApiController]
-[Route("deploy")]
+[Route("api/deploy")]
 public class DeploymentController(IDeploymentService deploymentService, IApplicationService applicationService, IKubernetesService kubernetesService) : ControllerBase
 {
     [HttpPost("{id:int}")]

--- a/helm-chart/templates/NOTES.txt
+++ b/helm-chart/templates/NOTES.txt
@@ -1,20 +1,20 @@
 1. Get the application URL by running these commands:
-{{- if .Values.app.ingress.enabled }}
-{{- range $host := .Values.app.ingress.hosts }}
+{{- if .Values.front.ingress.enabled }}
+{{- range $host := .Values.front.ingress.hosts }}
   {{- range .paths }}
-  http{{ if $.Values.app.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  http{{ if $.Values.front.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
   {{- end }}
 {{- end }}
-{{- else if contains "NodePort" .Values.app.service.type }}
+{{- else if contains "NodePort" .Values.front.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "evil-giraf.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT
-{{- else if contains "LoadBalancer" .Values.app.service.type }}
+{{- else if contains "LoadBalancer" .Values.front.service.type }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
            You can watch its status by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "evil-giraf.fullname" . }}'
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "evil-giraf.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
-  echo http://$SERVICE_IP:{{ .Values.app.service.port }}
-{{- else if contains "ClusterIP" .Values.app.service.type }}
+  echo http://$SERVICE_IP:{{ .Values.front.service.port }}
+{{- else if contains "ClusterIP" .Values.front.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "evil-giraf.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
   echo "Visit http://127.0.0.1:8080 to use your application"


### PR DESCRIPTION
Standardizes all API routes under an '/api' prefix for consistency and clarity. Adjusted tests, environment variables, and proxy configurations to accommodate the new route structure. Also removed redundant SonarQube caching steps in CI workflow.