### PR TITLE
fix: helm correct front serviceAccountName value reference

### DIFF
--- a/helm-chart/templates/_helpers.tpl
+++ b/helm-chart/templates/_helpers.tpl
@@ -69,9 +69,9 @@ Create the name of the service account to use
 {{- end }}
 {{- end }}
 {{- define "evil-giraf.front.serviceAccountName" -}}
-{{- if .Values.api.serviceAccount.create }}
-{{- default (printf "%s-front" (include "evil-giraf.fullname" .)) .Values.api.serviceAccount.name }}
+{{- if .Values.front.serviceAccount.create }}
+{{- default (printf "%s-front" (include "evil-giraf.fullname" .)) .Values.front.serviceAccount.name }}
 {{- else }}
-{{- default "default" .Values.api.serviceAccount.name }}
+{{- default "default" .Values.front.serviceAccount.name }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Updated the serviceAccountName logic to use `.Values.front` instead of `.Values.api` for consistency with the front-end configuration. This resolves potential misconfigurations when managing service accounts in the Helm chart.