### PR TITLE
refactor: CD move Git tag creation to the end of the workflow

### DIFF
--- a/.github/workflows/CD.yaml
+++ b/.github/workflows/CD.yaml
@@ -37,13 +37,6 @@ jobs:
         with:
           useConfigFile: true
 
-      - name: Create Git Tag
-        run: |
-          git config user.email "gitversion@evilgiraf.com"
-          git config user.name "GitVersion"
-          git tag -a v${{ steps.version.outputs.semVer }} -m "Release v${{ steps.version.outputs.semVer }}"
-          git push origin v${{ steps.version.outputs.semVer }}
-
       - name: Setup Kubernetes config
         run: |
           mkdir -p ~/.kube
@@ -67,3 +60,10 @@ jobs:
             --set api.auth.apiKey=${{ secrets.API_KEY }} \
             --set postgresql.auth.password=${{ secrets.POSTGRES_PASSWORD }} \
             --wait --timeout 15m
+
+      - name: Create Git Tag
+        run: |
+          git config user.email "gitversion@evilgiraf.com"
+          git config user.name "GitVersion"
+          git tag -a v${{ steps.version.outputs.semVer }} -m "Release v${{ steps.version.outputs.semVer }}"
+          git push origin v${{ steps.version.outputs.semVer }}


### PR DESCRIPTION
Repositioned the Git tag creation step for better sequencing in the CD pipeline. This ensures tagging occurs after all deployment steps, aligning with expected release flow.