### PR TITLE
feat: add undeploy endpoint with error handling and tests

### DIFF
--- a/EvilGiraf.IntegrationTests/DeploymentControllerTests.cs
+++ b/EvilGiraf.IntegrationTests/DeploymentControllerTests.cs
@@ -320,4 +320,112 @@ public class DeploymentControllerTests : AuthenticatedTestBase
         deployResponses![0].Status.Replicas.Should().Be(deployment.Status.Replicas);
         deployResponses[1].Status.Replicas.Should().Be(deployment.Status.Replicas);
     }
+    
+    [Fact]
+    public async Task Undeploy_ShouldReturn204_WhenDeploymentIsDeleted()
+    {
+        // Arrange
+        var application = new Application
+        {
+            Name = "test-app",
+            Type = ApplicationType.Docker,
+            Link = "docker.io/test-app:latest",
+            Version = "1.0.0",
+            Ports = [22]
+        };
+
+        _dbContext.Applications.Add(application);
+        await _dbContext.SaveChangesAsync();
+
+        _kubernetes.AppsV1.DeleteNamespacedDeploymentWithHttpMessagesAsync(
+            application.Name,
+            application.Id.ToNamespace())
+            .Returns(new HttpOperationResponse<V1Status> { Body = new V1Status() });
+
+        // Act
+        var response = await Client.DeleteAsync($"/api/deploy/application/{application.Id}/delete");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        await _kubernetes.AppsV1.Received(1).DeleteNamespacedDeploymentWithHttpMessagesAsync(
+            Arg.Is<string>(name => name == application.Name),
+            Arg.Is<string>(ns => ns == application.Id.ToNamespace()));
+    }
+
+    [Fact]
+    public async Task Undeploy_ShouldReturn404_WhenApplicationDoesNotExist()
+    {
+        // Act
+        var response = await Client.DeleteAsync("/api/deploy/application/999/delete");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        var error = await response.Content.ReadAsStringAsync();
+        error.Should().Contain("Application with ID 999 not found.");
+    }
+
+    [Fact]
+    public async Task Undeploy_ShouldReturn404_WhenDeploymentDoesNotExist()
+    {
+        // Arrange
+        var application = new Application
+        {
+            Name = "test-app",
+            Type = ApplicationType.Docker,
+            Link = "docker.io/test-app:latest",
+            Version = "1.0.0",
+            Ports = [22]
+        };
+
+        _dbContext.Applications.Add(application);
+        await _dbContext.SaveChangesAsync();
+
+        var httpException = new HttpOperationException
+        {
+            Response = new HttpResponseMessageWrapper(new HttpResponseMessage(HttpStatusCode.NotFound), string.Empty)
+        };
+
+        _kubernetes.AppsV1.DeleteNamespacedDeploymentWithHttpMessagesAsync(
+            application.Name,
+            application.Id.ToNamespace())
+            .Throws(httpException);
+
+        // Act
+        var response = await Client.DeleteAsync($"/api/deploy/application/{application.Id}/delete");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        var error = await response.Content.ReadAsStringAsync();
+        error.Should().Contain($"Deployment for application {application.Id} not found.");
+    }
+
+    [Fact]
+    public async Task Undeploy_ShouldReturn400_WhenExceptionOccurs()
+    {
+        // Arrange
+        var application = new Application
+        {
+            Name = "test-app",
+            Type = ApplicationType.Docker,
+            Link = "docker.io/test-app:latest",
+            Version = "1.0.0",
+            Ports = [22]
+        };
+
+        _dbContext.Applications.Add(application);
+        await _dbContext.SaveChangesAsync();
+
+        _kubernetes.AppsV1.DeleteNamespacedDeploymentWithHttpMessagesAsync(
+            application.Name,
+            application.Id.ToNamespace())
+            .Throws(new Exception("Unexpected error"));
+
+        // Act
+        var response = await Client.DeleteAsync($"/api/deploy/application/{application.Id}/delete");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var error = await response.Content.ReadAsStringAsync();
+        error.Should().Contain("Error deleting deployment: Unexpected error");
+    }
 }

--- a/EvilGiraf/Controller/DeploymentController.cs
+++ b/EvilGiraf/Controller/DeploymentController.cs
@@ -59,4 +59,33 @@ public class DeploymentController(IDeploymentService deploymentService, IApplica
         }
         return Ok(listDeployResponses);
     }
+    
+    [HttpDelete("application/{id:int}/delete")]
+    [ProducesResponseType(204)]
+    [ProducesResponseType(typeof(string), 400)]
+    [ProducesResponseType(typeof(string), 404)]
+    public async Task<IActionResult> Undeploy(int id)
+    {
+        var application = await applicationService.GetApplication(id);
+        if (application == null)
+        {
+            return NotFound($"Application with ID {id} not found.");
+        }
+
+        try
+        {
+            var result = await deploymentService.DeleteDeployment(application.Name, application.Id.ToNamespace());
+            if (result == null)
+            {
+                return NotFound($"Deployment for application {id} not found.");
+            }
+
+            return NoContent();
+        }
+        catch(Exception ex)
+        {
+            return BadRequest($"Error deleting deployment: {ex.Message}");
+            
+        }
+    }
 }


### PR DESCRIPTION
This pull request introduces new functionality for undeploying applications and includes corresponding tests. The most important changes are the addition of the `Undeploy` method in the `DeploymentController` and several new test cases to ensure proper behavior.

### New functionality for undeploying applications:

* [`EvilGiraf/Controller/DeploymentController.cs`](diffhunk://#diff-246f60aa2f10d3618ceb33839487d4d43d05834f1733b5731357b7646f06d268R62-R90): Added the `Undeploy` method to handle HTTP DELETE requests for undeploying applications, including appropriate response types for different scenarios.

### New test cases for undeploying applications:

* [`EvilGiraf.IntegrationTests/DeploymentControllerTests.cs`](diffhunk://#diff-2b8550fdb2e5c7611e33b2349f1c866a5f3e921d835d042a1e493d32ee5d4e6fR323-R430): Added multiple test cases to verify the behavior of the `Undeploy` method, including scenarios where the deployment is successfully deleted, the application does not exist, the deployment does not exist, and an exception occurs.

closes #107