### PR TITLE
feat: introduce namespace management service

### DIFF
--- a/EvilGiraf.IntegrationTests/DeploymentControllerTests.cs
+++ b/EvilGiraf.IntegrationTests/DeploymentControllerTests.cs
@@ -55,6 +55,8 @@ public class DeploymentControllerTests : AuthenticatedTestBase
                 application.Id.ToNamespace())
             .Returns(deployment);
         
+        _kubernetes.CoreV1.ReadNamespaceWithHttpMessagesAsync(Arg.Any<string>()).Returns(new HttpOperationResponse<V1Namespace>{ Body = new V1Namespace() });
+        
         _kubernetes.AppsV1.ReplaceNamespacedDeploymentWithHttpMessagesAsync(
                 Arg.Any<V1Deployment>(),
                 application.Name, 
@@ -62,19 +64,19 @@ public class DeploymentControllerTests : AuthenticatedTestBase
             .Returns(deployment);
 
         // Act
-        var response = await Client.PostAsync($"/api/deploy/{application.Id}", null);
+        var response = await Client.PostAsync($"/api/deploy/{application.Id}?isAsync=false", null);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Created);
 
         await _kubernetes.AppsV1.Received().ReadNamespacedDeploymentWithHttpMessagesAsync(
-            Arg.Is<string>(name => name == application.Name),
-            Arg.Is<string>(ns => ns == application.Id.ToNamespace()));
+            application.Name,
+            application.Id.ToNamespace());
 
         await _kubernetes.AppsV1.Received().ReplaceNamespacedDeploymentWithHttpMessagesAsync(
             Arg.Any<V1Deployment>(),
-            Arg.Is<string>(name => name == application.Name),
-            Arg.Is<string>(ns => ns == application.Id.ToNamespace()));
+            application.Name,
+            application.Id.ToNamespace());
     }
 
     [Fact]
@@ -120,17 +122,17 @@ public class DeploymentControllerTests : AuthenticatedTestBase
                 application.Id.ToNamespace())
             .Returns(deployment);
         
-        _kubernetes.CoreV1.ReadNamespaceWithHttpMessagesAsync(Arg.Any<string>()).Returns(new HttpOperationResponse<V1Namespace>());
+        _kubernetes.CoreV1.ReadNamespaceWithHttpMessagesAsync(Arg.Any<string>()).Returns(new HttpOperationResponse<V1Namespace>{ Body = new V1Namespace()});
         
         // Act
-        var response = await Client.PostAsync($"/api/deploy/{application.Id}", null);
+        var response = await Client.PostAsync($"/api/deploy/{application.Id}?isAsync=false", null);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Created);
 
         await _kubernetes.AppsV1.Received().ReadNamespacedDeploymentWithHttpMessagesAsync(
-            Arg.Is<string>(name => name == application.Name),
-            Arg.Is<string>(ns => ns == application.Id.ToNamespace()));
+            application.Name,
+            application.Id.ToNamespace());
     }
 
     [Fact]

--- a/EvilGiraf.Tests/DeploymentTests.cs
+++ b/EvilGiraf.Tests/DeploymentTests.cs
@@ -1,7 +1,7 @@
 using System.Net;
-using EvilGiraf.Interface;
+using EvilGiraf.Interface.Kubernetes;
 using EvilGiraf.Model;
-using EvilGiraf.Service;
+using EvilGiraf.Service.Kubernetes;
 using FluentAssertions;
 using k8s;
 using k8s.Autorest;

--- a/EvilGiraf.Tests/KubernetesTests.cs
+++ b/EvilGiraf.Tests/KubernetesTests.cs
@@ -1,4 +1,4 @@
-using EvilGiraf.Interface;
+using EvilGiraf.Interface.Kubernetes;
 using EvilGiraf.Model;
 using EvilGiraf.Service;
 using FluentAssertions;
@@ -16,7 +16,7 @@ public class KubernetesTests
     public KubernetesTests()
     {
         _deploymentService = Substitute.For<IDeploymentService>();
-        _kubernetesService = new KubernetesService(_deploymentService);
+        _kubernetesService = new KubernetesService(_deploymentService, Substitute.For<INamespaceService>());
     }
 
     private static Application CreateTestApplication() => new()

--- a/EvilGiraf/Controller/DeploymentController.cs
+++ b/EvilGiraf/Controller/DeploymentController.cs
@@ -1,5 +1,6 @@
 using EvilGiraf.Dto;
 using EvilGiraf.Interface;
+using EvilGiraf.Interface.Kubernetes;
 using EvilGiraf.Model;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;

--- a/EvilGiraf/Controller/DeploymentController.cs
+++ b/EvilGiraf/Controller/DeploymentController.cs
@@ -15,13 +15,16 @@ public class DeploymentController(IDeploymentService deploymentService, IApplica
     [HttpPost("{id:int}")]
     [ProducesResponseType(201)]
     [ProducesResponseType(typeof(string), 404)]
-    public async  Task<IActionResult> Deploy(int id)
+    public async  Task<IActionResult> Deploy(int id, [FromQuery] bool isAsync = true)
     {
         var app = await applicationService.GetApplication(id);
         if (app is null)
             return NotFound($"Application {id} not found");
         
-        _ = kubernetesService.Deploy(app);
+        if (isAsync)
+            _ = kubernetesService.Deploy(app);
+        else
+            await kubernetesService.Deploy(app);
         
         return Created($"deploy/{id:int}", null);
     }

--- a/EvilGiraf/Interface/Kubernetes/IDeploymentService.cs
+++ b/EvilGiraf/Interface/Kubernetes/IDeploymentService.cs
@@ -1,7 +1,7 @@
 using EvilGiraf.Model;
 using k8s.Models;
 
-namespace EvilGiraf.Interface;
+namespace EvilGiraf.Interface.Kubernetes;
 
 public interface IDeploymentService
 {

--- a/EvilGiraf/Interface/Kubernetes/INamespaceService.cs
+++ b/EvilGiraf/Interface/Kubernetes/INamespaceService.cs
@@ -1,0 +1,12 @@
+using k8s.Models;
+
+namespace EvilGiraf.Interface.Kubernetes;
+
+public interface INamespaceService
+{
+    public Task<V1Namespace> CreateNamespace(string name);
+
+    public Task<V1Namespace?> ReadNamespace(string name);
+
+    public Task<V1Namespace?> CreateIfNotExistsNamespace(string name);
+}  

--- a/EvilGiraf/Program.cs
+++ b/EvilGiraf/Program.cs
@@ -1,7 +1,9 @@
 using System.Diagnostics.CodeAnalysis;
 using EvilGiraf.Authentication;
 using EvilGiraf.Interface;
+using EvilGiraf.Interface.Kubernetes;
 using EvilGiraf.Service;
+using EvilGiraf.Service.Kubernetes;
 using k8s;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.OpenApi.Models;
@@ -62,6 +64,7 @@ public class Program
                 builder.Configuration.GetSection("Postgres")
                 .Get<NpgsqlConnectionStringBuilder>()?.ConnectionString));
         builder.Services.AddSingleton<IDeploymentService, DeploymentService>();
+        builder.Services.AddSingleton<INamespaceService, NamespaceService>();
         builder.Services.AddScoped<IApplicationService, ApplicationService>();
         builder.Services.AddScoped<IKubernetesService, KubernetesService>();
 

--- a/EvilGiraf/Service/Kubernetes/DeploymentService.cs
+++ b/EvilGiraf/Service/Kubernetes/DeploymentService.cs
@@ -1,24 +1,15 @@
-using EvilGiraf.Interface;
+using EvilGiraf.Interface.Kubernetes;
 using EvilGiraf.Model;
 using k8s;
 using k8s.Autorest;
 using k8s.Models;
 
-namespace EvilGiraf.Service;
+namespace EvilGiraf.Service.Kubernetes;
 
 public class DeploymentService(IKubernetes client) : IDeploymentService
 {
     public async Task<V1Deployment> CreateDeployment(DeploymentModel model)
     {
-        try
-        {
-            await client.CoreV1.ReadNamespaceAsync(model.Namespace);
-        }
-        catch (HttpOperationException ex) when (ex.Response.StatusCode == System.Net.HttpStatusCode.NotFound)
-        {
-            await client.CoreV1.CreateNamespaceAsync(new V1Namespace { Metadata = new V1ObjectMeta { Name = model.Namespace } });
-        }
-        
         return await client.AppsV1.CreateNamespacedDeploymentAsync(model.ToDeployment(), model.Namespace);
     }
     

--- a/EvilGiraf/Service/Kubernetes/NamespaceService.cs
+++ b/EvilGiraf/Service/Kubernetes/NamespaceService.cs
@@ -1,0 +1,33 @@
+using EvilGiraf.Interface.Kubernetes;
+using k8s;
+using k8s.Autorest;
+using k8s.Models;
+
+namespace EvilGiraf.Service.Kubernetes;
+
+public class NamespaceService(IKubernetes client) : INamespaceService
+{
+    public async Task<V1Namespace> CreateNamespace(string name)
+    {
+        return await client.CoreV1.CreateNamespaceAsync(new V1Namespace { Metadata = new V1ObjectMeta { Name = name } });
+    }
+
+    public async Task<V1Namespace?> ReadNamespace(string name)
+    {
+        try
+        {
+            return await client.CoreV1.ReadNamespaceAsync(name);
+        }
+        catch (HttpOperationException ex) when (ex.Response.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            return null;
+        }
+    }
+
+    public async Task<V1Namespace?> CreateIfNotExistsNamespace(string name)
+    {
+        if (await ReadNamespace(name) is { } @namespace)
+            return @namespace;
+        return await CreateNamespace(name);
+    }
+}  

--- a/EvilGiraf/Service/KubernetesService.cs
+++ b/EvilGiraf/Service/KubernetesService.cs
@@ -1,12 +1,14 @@
 using EvilGiraf.Interface;
+using EvilGiraf.Interface.Kubernetes;
 using EvilGiraf.Model;
 
 namespace EvilGiraf.Service;
 
-public class KubernetesService(IDeploymentService deploymentService) : IKubernetesService
+public class KubernetesService(IDeploymentService deploymentService, INamespaceService namespaceService) : IKubernetesService
 {
     public async Task Deploy(Application app)
     {
+        await namespaceService.CreateIfNotExistsNamespace(app.Id.ToNamespace());
         var deployment = await deploymentService.ReadDeployment(app.Name, app.Id.ToNamespace());
         if (deployment is null)
         {


### PR DESCRIPTION
Added `NamespaceService` to handle Kubernetes namespace operations, including creation and retrieval. Updated `KubernetesService` to leverage `NamespaceService` for namespace management to improve modularity and code clarity. Refactored interfaces and services to align with the new namespace handling logic.