### PR TITLE
98 service creation

### DIFF
--- a/EvilGiraf.IntegrationTests/DeploymentControllerTests.cs
+++ b/EvilGiraf.IntegrationTests/DeploymentControllerTests.cs
@@ -46,6 +46,10 @@ public class DeploymentControllerTests : AuthenticatedTestBase
                 }
             }
         };
+        var service = new HttpOperationResponse<V1Service>
+        {
+            Body = new V1Service()
+        };
         
         _dbContext.Applications.Add(application);
         await _dbContext.SaveChangesAsync();
@@ -54,6 +58,11 @@ public class DeploymentControllerTests : AuthenticatedTestBase
                 application.Name, 
                 application.Id.ToNamespace())
             .Returns(deployment);
+        
+        _kubernetes.CoreV1.ReadNamespacedServiceWithHttpMessagesAsync(
+                application.Name, 
+                application.Id.ToNamespace())
+            .Returns(service);
         
         _kubernetes.CoreV1.ReadNamespaceWithHttpMessagesAsync(Arg.Any<string>()).Returns(new HttpOperationResponse<V1Namespace>{ Body = new V1Namespace() });
         
@@ -103,6 +112,10 @@ public class DeploymentControllerTests : AuthenticatedTestBase
                 }
             }
         };
+        var service = new HttpOperationResponse<V1Service>
+        {
+            Body = new V1Service()
+        };
         
         var httpException = new HttpOperationException
         {
@@ -121,6 +134,11 @@ public class DeploymentControllerTests : AuthenticatedTestBase
                 Arg.Any<V1Deployment>(),
                 application.Id.ToNamespace())
             .Returns(deployment);
+        
+        _kubernetes.CoreV1.CreateNamespacedServiceWithHttpMessagesAsync(
+                Arg.Any<V1Service>(), 
+                application.Id.ToNamespace())
+            .Returns(service);
         
         _kubernetes.CoreV1.ReadNamespaceWithHttpMessagesAsync(Arg.Any<string>()).Returns(new HttpOperationResponse<V1Namespace>{ Body = new V1Namespace()});
         

--- a/EvilGiraf.Tests/KubernetesTests.cs
+++ b/EvilGiraf.Tests/KubernetesTests.cs
@@ -1,4 +1,5 @@
 using EvilGiraf.Interface.Kubernetes;
+using EvilGiraf.Interface;
 using EvilGiraf.Model;
 using EvilGiraf.Service;
 using FluentAssertions;
@@ -16,7 +17,7 @@ public class KubernetesTests
     public KubernetesTests()
     {
         _deploymentService = Substitute.For<IDeploymentService>();
-        _kubernetesService = new KubernetesService(_deploymentService, Substitute.For<INamespaceService>());
+        _kubernetesService = new KubernetesService(_deploymentService, Substitute.For<INamespaceService>(), Substitute.For<IServiceService>());
     }
 
     private static Application CreateTestApplication() => new()

--- a/EvilGiraf.Tests/ServiceTests.cs
+++ b/EvilGiraf.Tests/ServiceTests.cs
@@ -1,0 +1,52 @@
+using EvilGiraf.Interface;
+using EvilGiraf.Interface.Kubernetes;
+using EvilGiraf.Model;
+using EvilGiraf.Service.Kubernetes;
+using FluentAssertions;
+using k8s.Models;
+using k8s;
+using k8s.Autorest;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+
+namespace EvilGiraf.Tests;
+
+public class ServiceTests
+{
+    public IKubernetes Kubernetes { get; }
+    public IServiceService ServiceService { get; }
+
+    public ServiceTests()
+    {
+        Kubernetes = Substitute.For<IKubernetes>();
+
+        ServiceService = new ServiceService(Kubernetes);
+
+        var appv1OperationsSubstitute = Substitute.For<IAppsV1Operations>();
+
+        var deploymentResponse = new HttpOperationResponse<V1Deployment>();
+        deploymentResponse.Body = new V1Deployment();
+        appv1OperationsSubstitute.CreateNamespacedDeploymentWithHttpMessagesAsync(Arg.Any<V1Deployment>(), Arg.Any<string>())
+            .Returns(deploymentResponse);
+
+        var deleteResponse = new HttpOperationResponse<V1Status>();
+        deleteResponse.Body = new V1Status();
+        appv1OperationsSubstitute.DeleteNamespacedDeploymentWithHttpMessagesAsync(Arg.Any<string>(), Arg.Any<string>())
+            .Returns(deleteResponse);
+
+        var updateResponse = new HttpOperationResponse<V1Deployment>();
+        updateResponse.Body = new V1Deployment();
+        appv1OperationsSubstitute.ReplaceNamespacedDeploymentWithHttpMessagesAsync(Arg.Any<V1Deployment>(), Arg.Any<string>(), Arg.Any<string>(), null, null, null, null, null, Arg.Any<CancellationToken>())
+            .Returns(updateResponse);
+
+        Kubernetes.AppsV1.Returns(appv1OperationsSubstitute);
+        
+        var corev1OperationsSubstitute = Substitute.For<ICoreV1Operations>();
+        corev1OperationsSubstitute.ReadNamespaceWithHttpMessagesAsync(Arg.Any<string>()).Returns(new HttpOperationResponse<V1Namespace>());
+        
+        Kubernetes.CoreV1.Returns(corev1OperationsSubstitute);
+        
+        ServiceService = new ServiceService(Kubernetes);
+    }
+    
+}

--- a/EvilGiraf.Tests/ServiceTests.cs
+++ b/EvilGiraf.Tests/ServiceTests.cs
@@ -1,5 +1,5 @@
+using System.Net;
 using EvilGiraf.Interface;
-using EvilGiraf.Interface.Kubernetes;
 using EvilGiraf.Model;
 using EvilGiraf.Service.Kubernetes;
 using FluentAssertions;
@@ -19,34 +19,256 @@ public class ServiceTests
     public ServiceTests()
     {
         Kubernetes = Substitute.For<IKubernetes>();
-
-        ServiceService = new ServiceService(Kubernetes);
-
-        var appv1OperationsSubstitute = Substitute.For<IAppsV1Operations>();
-
-        var deploymentResponse = new HttpOperationResponse<V1Deployment>();
-        deploymentResponse.Body = new V1Deployment();
-        appv1OperationsSubstitute.CreateNamespacedDeploymentWithHttpMessagesAsync(Arg.Any<V1Deployment>(), Arg.Any<string>())
-            .Returns(deploymentResponse);
-
-        var deleteResponse = new HttpOperationResponse<V1Status>();
-        deleteResponse.Body = new V1Status();
-        appv1OperationsSubstitute.DeleteNamespacedDeploymentWithHttpMessagesAsync(Arg.Any<string>(), Arg.Any<string>())
-            .Returns(deleteResponse);
-
-        var updateResponse = new HttpOperationResponse<V1Deployment>();
-        updateResponse.Body = new V1Deployment();
-        appv1OperationsSubstitute.ReplaceNamespacedDeploymentWithHttpMessagesAsync(Arg.Any<V1Deployment>(), Arg.Any<string>(), Arg.Any<string>(), null, null, null, null, null, Arg.Any<CancellationToken>())
-            .Returns(updateResponse);
-
-        Kubernetes.AppsV1.Returns(appv1OperationsSubstitute);
         
         var corev1OperationsSubstitute = Substitute.For<ICoreV1Operations>();
-        corev1OperationsSubstitute.ReadNamespaceWithHttpMessagesAsync(Arg.Any<string>()).Returns(new HttpOperationResponse<V1Namespace>());
         
+        var serviceResponse = new HttpOperationResponse<V1Service>();
+        serviceResponse.Body = new V1Service();
+        corev1OperationsSubstitute.CreateNamespacedServiceWithHttpMessagesAsync(Arg.Any<V1Service>(), Arg.Any<string>())
+            .Returns(serviceResponse);
+            
+        var deleteResponse = new HttpOperationResponse<V1Service>{ Body = new V1Service()};
+        corev1OperationsSubstitute.DeleteNamespacedServiceWithHttpMessagesAsync(Arg.Any<string>(), Arg.Any<string>())
+            .Returns(deleteResponse);
+            
+        var updateResponse = new HttpOperationResponse<V1Service>();
+        updateResponse.Body = new V1Service();
+        corev1OperationsSubstitute.ReplaceNamespacedServiceWithHttpMessagesAsync(Arg.Any<V1Service>(), Arg.Any<string>(), Arg.Any<string>(), null, null, null, null, null, Arg.Any<CancellationToken>())
+            .Returns(updateResponse);
+            
+        corev1OperationsSubstitute.ReadNamespaceWithHttpMessagesAsync(Arg.Any<string>())
+            .Returns(new HttpOperationResponse<V1Namespace>());
+            
         Kubernetes.CoreV1.Returns(corev1OperationsSubstitute);
         
         ServiceService = new ServiceService(Kubernetes);
     }
     
+    [Fact]
+    public async Task CreateService_Should_Return_Service()
+    {
+        var model = new ServiceModel(
+            "service-test",
+            "default",
+            "ClusterIP",
+            [80],
+            "TCP",
+            "app-test"
+        );
+        var result = await ServiceService.CreateService(model);
+        result.Should().NotBeNull();
+        result.Should().BeOfType<V1Service>();
+        await Kubernetes.CoreV1.Received().CreateNamespacedServiceWithHttpMessagesAsync(Arg.Any<V1Service>(), "default");
+    }
+    
+    [Fact]
+    public async Task CreateService_with_namespace_not_exist_Should_Return_Service()
+    {
+        var response = new HttpOperationException
+        {
+            Response = new HttpResponseMessageWrapper(new HttpResponseMessage(HttpStatusCode.NotFound), string.Empty)
+        };
+        Kubernetes.CoreV1.ReadNamespaceWithHttpMessagesAsync(Arg.Any<string>()).Throws(response);
+        Kubernetes.CoreV1.CreateNamespaceWithHttpMessagesAsync(Arg.Any<V1Namespace>()).Returns(new HttpOperationResponse<V1Namespace>());
+        
+        var model = new ServiceModel(
+            "service-test",
+            "default",
+            "ClusterIP",
+            [80],
+            "TCP",
+            "app-test"
+        );
+        var result = await ServiceService.CreateService(model);
+        result.Should().NotBeNull();
+        result.Should().BeOfType<V1Service>();
+        await Kubernetes.CoreV1.Received().CreateNamespacedServiceWithHttpMessagesAsync(Arg.Any<V1Service>(), "default");
+    }
+    
+    [Fact]
+    public async Task ReadService_Should_Return_Service()
+    {
+        var serviceName = "service-test";
+        var @namespace = "default";
+
+        var serviceResponse = new HttpOperationResponse<V1Service>
+        {
+            Body = new V1Service
+            {
+                Metadata = new V1ObjectMeta
+                {
+                    Name = serviceName,
+                    NamespaceProperty = @namespace
+                }
+            }
+        };
+
+        Kubernetes.CoreV1.ReadNamespacedServiceWithHttpMessagesAsync(serviceName, @namespace, null, null, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(serviceResponse));
+
+        var result = await ServiceService.ReadService(serviceName, @namespace);
+        
+        result.Should().NotBeNull();
+        result!.Metadata.Name.Should().Be(serviceName);
+        result.Metadata.NamespaceProperty.Should().Be(@namespace);
+        
+        await Kubernetes.CoreV1.Received().ReadNamespacedServiceWithHttpMessagesAsync(serviceName, @namespace, null, null, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ReadService_Should_Return_null_When_NotFound()
+    {
+        var serviceName = "non-existent-service";
+        var @namespace = "default";
+
+        var httpException = new HttpOperationException
+        {
+            Response = new HttpResponseMessageWrapper(new HttpResponseMessage(HttpStatusCode.NotFound), string.Empty)
+        };
+
+        Kubernetes.CoreV1.ReadNamespacedServiceWithHttpMessagesAsync(serviceName, @namespace, null, null, Arg.Any<CancellationToken>())
+            .Throws(httpException);
+
+        var result = await ServiceService.ReadService(serviceName, @namespace);
+        
+        result.Should().BeNull();
+
+        await Kubernetes.CoreV1.Received().ReadNamespacedServiceWithHttpMessagesAsync(serviceName, @namespace, null, null, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DeleteService_Should_Return_Service()
+    {
+        var result = await ServiceService.DeleteService("service-test", "default");
+        result.Should().NotBeNull()
+            .And.BeOfType<V1Service>();
+        await Kubernetes.CoreV1.Received().DeleteNamespacedServiceWithHttpMessagesAsync("service-test", "default");
+    }
+
+    [Fact]
+    public async Task DeleteService_Should_Return_Null()
+    {
+        var httpException = new HttpOperationException
+        {
+            Response = new HttpResponseMessageWrapper(new HttpResponseMessage(HttpStatusCode.NotFound), string.Empty)
+        };
+        Kubernetes.CoreV1.DeleteNamespacedServiceWithHttpMessagesAsync("service-test", "default")
+            .Throws(httpException);
+        var result = await ServiceService.DeleteService("service-test", "default");
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task UpdateService_Should_Return_Service()
+    {
+        var model = new ServiceModel(
+            "service-test",
+            "default",
+            "ClusterIP",
+            [80],
+            "TCP",
+            "app-test"
+        );
+        var result = await ServiceService.UpdateService(model);
+        result.Should().NotBeNull();
+        result.Should().BeOfType<V1Service>();
+        await Kubernetes.CoreV1.Received().ReplaceNamespacedServiceWithHttpMessagesAsync(Arg.Any<V1Service>(), "service-test", "default", null, null, null, null, null, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task UpdateService_Should_Return_Null()
+    {
+        var model = new ServiceModel(
+            "service-test",
+            "default",
+            "ClusterIP",
+            [80],
+            "TCP",
+            "app-test"
+        );
+        var httpException = new HttpOperationException
+        {
+            Response = new HttpResponseMessageWrapper(new HttpResponseMessage(HttpStatusCode.NotFound), string.Empty)
+        };
+        Kubernetes.CoreV1.ReplaceNamespacedServiceWithHttpMessagesAsync(Arg.Any<V1Service>(), "service-test", "default", null, null, null, null, null, Arg.Any<CancellationToken>())
+            .Throws(httpException);
+        var result = await ServiceService.UpdateService(model);
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task CreateIfNotExistsService_Should_Return_Existing_Service()
+    {
+        var model = new ServiceModel(
+            "service-test",
+            "default",
+            "ClusterIP",
+            [80],
+            "TCP",
+            "app-test"
+        );
+        
+        var existingService = new V1Service
+        {
+            Metadata = new V1ObjectMeta
+            {
+                Name = model.Name,
+                NamespaceProperty = model.Namespace
+            }
+        };
+        
+        Kubernetes.CoreV1.ReadNamespacedServiceWithHttpMessagesAsync(model.Name, model.Namespace, null, null, Arg.Any<CancellationToken>())
+            .Returns(new HttpOperationResponse<V1Service> { Body = existingService });
+
+        var result = await ServiceService.CreateIfNotExistsService(model);
+        
+        result.Should().NotBeNull();
+        result.Should().BeOfType<V1Service>();
+        result.Metadata.Name.Should().Be(model.Name);
+        result.Metadata.NamespaceProperty.Should().Be(model.Namespace);
+        
+        await Kubernetes.CoreV1.DidNotReceive().CreateNamespacedServiceWithHttpMessagesAsync(Arg.Any<V1Service>(), Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task CreateIfNotExistsService_Should_Create_New_Service()
+    {
+        var model = new ServiceModel(
+            "service-test",
+            "default",
+            "ClusterIP",
+            [80],
+            "TCP",
+            "app-test"
+        );
+        
+        var httpException = new HttpOperationException
+        {
+            Response = new HttpResponseMessageWrapper(new HttpResponseMessage(HttpStatusCode.NotFound), string.Empty)
+        };
+        
+        Kubernetes.CoreV1.ReadNamespacedServiceWithHttpMessagesAsync(model.Name, model.Namespace, null, null, Arg.Any<CancellationToken>())
+            .Throws(httpException);
+            
+        var newService = new V1Service
+        {
+            Metadata = new V1ObjectMeta
+            {
+                Name = model.Name,
+                NamespaceProperty = model.Namespace
+            }
+        };
+        
+        Kubernetes.CoreV1.CreateNamespacedServiceWithHttpMessagesAsync(Arg.Any<V1Service>(), Arg.Any<string>())
+            .Returns(new HttpOperationResponse<V1Service> { Body = newService });
+
+        var result = await ServiceService.CreateIfNotExistsService(model);
+        
+        result.Should().NotBeNull();
+        result.Should().BeOfType<V1Service>();
+        result.Metadata.Name.Should().Be(model.Name);
+        result.Metadata.NamespaceProperty.Should().Be(model.Namespace);
+        
+        await Kubernetes.CoreV1.Received().CreateNamespacedServiceWithHttpMessagesAsync(Arg.Any<V1Service>(), model.Namespace);
+    }
 }

--- a/EvilGiraf/Interface/Kubernetes/IServiceService.cs
+++ b/EvilGiraf/Interface/Kubernetes/IServiceService.cs
@@ -1,0 +1,15 @@
+using EvilGiraf.Model;
+using k8s.Models;
+
+namespace EvilGiraf.Interface;
+
+public interface IServiceService
+{
+    Task<V1Service> CreateService(ServiceModel model);
+    
+    Task<V1Service?> ReadService(string name, string @namespace);
+    
+    Task<V1Service?> UpdateService(ServiceModel model);
+    
+    Task<V1Service?> DeleteService(string name, string @namespace);
+}

--- a/EvilGiraf/Interface/Kubernetes/IServiceService.cs
+++ b/EvilGiraf/Interface/Kubernetes/IServiceService.cs
@@ -5,11 +5,13 @@ namespace EvilGiraf.Interface;
 
 public interface IServiceService
 {
-    Task<V1Service> CreateService(ServiceModel model);
+    public Task<V1Service> CreateService(ServiceModel model);
     
-    Task<V1Service?> ReadService(string name, string @namespace);
+    public Task<V1Service?> ReadService(string name, string @namespace);
     
-    Task<V1Service?> UpdateService(ServiceModel model);
+    public Task<V1Service?> UpdateService(ServiceModel model);
     
-    Task<V1Service?> DeleteService(string name, string @namespace);
+    public Task<V1Service?> DeleteService(string name, string @namespace);
+
+    public Task<V1Service> CreateIfNotExistsService(ServiceModel model);
 }

--- a/EvilGiraf/Model/ServiceModel.cs
+++ b/EvilGiraf/Model/ServiceModel.cs
@@ -1,0 +1,46 @@
+using k8s.Models;
+
+namespace EvilGiraf.Model;
+
+public class ServiceModel
+{
+    public required string Name { get; set; }
+    
+    public required string Namespace { get; set; }
+    
+    public required string Type { get; set; }
+    
+    public required int[] Ports { get; set; }
+    
+    public required string TargetPort { get; set; }
+    
+    public required string Protocol { get; set; }
+    
+    public required string Selector { get; set; }
+    
+    public V1Service ToService()
+    {
+        return new V1Service
+        {
+            Metadata = new V1ObjectMeta
+            {
+                Name = Name,
+                NamespaceProperty = Namespace
+            },
+            Spec = new V1ServiceSpec
+            {
+                Type = Type,
+                Ports = Ports.Select(p => new V1ServicePort
+                {
+                    Port = p,
+                    TargetPort = TargetPort,
+                    Protocol = Protocol
+                }).ToList(),
+                Selector = new Dictionary<string, string>
+                {
+                    { "app", Selector }
+                }
+            }
+        };
+    }
+}

--- a/EvilGiraf/Model/ServiceModel.cs
+++ b/EvilGiraf/Model/ServiceModel.cs
@@ -2,43 +2,31 @@ using k8s.Models;
 
 namespace EvilGiraf.Model;
 
-public class ServiceModel
-{
-    public required string Name { get; set; }
-    
-    public required string Namespace { get; set; }
-    
-    public required string Type { get; set; }
-    
-    public required int[] Ports { get; set; }
-    
-    public required string TargetPort { get; set; }
-    
-    public required string Protocol { get; set; }
-    
-    public required string Selector { get; set; }
-    
-    public V1Service ToService()
+public record ServiceModel(string Name, string Namespace, string Type, int[] Ports, string Protocol, string Selector);
+
+public static class ServiceModelExtensions
+{   
+    public static V1Service ToService(this ServiceModel model)
     {
         return new V1Service
         {
             Metadata = new V1ObjectMeta
             {
-                Name = Name,
-                NamespaceProperty = Namespace
+                Name = model.Name,
+                NamespaceProperty = model.Namespace
             },
             Spec = new V1ServiceSpec
             {
-                Type = Type,
-                Ports = Ports.Select(p => new V1ServicePort
+                Type = model.Type,
+                Ports = model.Ports.Select(p => new V1ServicePort
                 {
                     Port = p,
-                    TargetPort = TargetPort,
-                    Protocol = Protocol
+                    TargetPort = p,
+                    Protocol = model.Protocol
                 }).ToList(),
                 Selector = new Dictionary<string, string>
                 {
-                    { "app", Selector }
+                    { "app", model.Selector }
                 }
             }
         };

--- a/EvilGiraf/Program.cs
+++ b/EvilGiraf/Program.cs
@@ -67,6 +67,7 @@ public class Program
         builder.Services.AddSingleton<INamespaceService, NamespaceService>();
         builder.Services.AddScoped<IApplicationService, ApplicationService>();
         builder.Services.AddScoped<IKubernetesService, KubernetesService>();
+        builder.Services.AddScoped<IServiceService, ServiceService>();
 
         var app = builder.Build();
 

--- a/EvilGiraf/Service/Kubernetes/ServiceService.cs
+++ b/EvilGiraf/Service/Kubernetes/ServiceService.cs
@@ -4,7 +4,7 @@ using k8s;
 using k8s.Autorest;
 using k8s.Models;
 
-namespace EvilGiraf.Service;
+namespace EvilGiraf.Service.Kubernetes;
 
 public class ServiceService(IKubernetes client) : IServiceService
 {
@@ -57,5 +57,12 @@ public class ServiceService(IKubernetes client) : IServiceService
         {
             return null;
         }
+    }
+
+    public async Task<V1Service> CreateIfNotExistsService(ServiceModel model)
+    {
+        if (await ReadService(model.Name, model.Namespace) is { } service)
+            return service;
+        return await CreateService(model);
     }
 }

--- a/EvilGiraf/Service/Kubernetes/ServiceService.cs
+++ b/EvilGiraf/Service/Kubernetes/ServiceService.cs
@@ -1,0 +1,61 @@
+using EvilGiraf.Interface;
+using EvilGiraf.Model;
+using k8s;
+using k8s.Autorest;
+using k8s.Models;
+
+namespace EvilGiraf.Service;
+
+public class ServiceService(IKubernetes client) : IServiceService
+{
+    public async Task<V1Service> CreateService(ServiceModel model)
+    {
+        try
+        {
+            await client.CoreV1.ReadNamespaceAsync(model.Namespace);
+        }
+        catch (HttpOperationException ex) when (ex.Response.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            await client.CoreV1.CreateNamespaceAsync(new V1Namespace { Metadata = new V1ObjectMeta { Name = model.Namespace } });
+        }
+
+        return await client.CoreV1.CreateNamespacedServiceAsync(model.ToService(), model.Namespace);
+    }
+
+    public async Task<V1Service?> ReadService(string name, string @namespace)
+    {
+        try
+        {
+            var service = await client.CoreV1.ReadNamespacedServiceAsync(name, @namespace);
+            return service;
+        }
+        catch (HttpOperationException ex) when (ex.Response.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            return null;
+        }
+    }
+
+    public async Task<V1Service?> UpdateService(ServiceModel model)
+    {
+        try
+        {
+            return await client.CoreV1.ReplaceNamespacedServiceAsync(model.ToService(), model.Name, model.Namespace);
+        }
+        catch (HttpOperationException ex) when (ex.Response.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            return null;
+        }
+    }
+
+    public async Task<V1Service?> DeleteService(string name, string @namespace)
+    {
+        try
+        {
+            return await client.CoreV1.DeleteNamespacedServiceAsync(name, @namespace);
+        }
+        catch (HttpOperationException ex) when (ex.Response.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            return null;
+        }
+    }
+}

--- a/EvilGiraf/Service/KubernetesService.cs
+++ b/EvilGiraf/Service/KubernetesService.cs
@@ -25,6 +25,21 @@ public class KubernetesService(IDeploymentService deploymentService, INamespaceS
         {
             await deploymentService.UpdateDeployment(new DeploymentModel(app.Name, app.Id.ToNamespace(), 1,
                 app.Link, app.Ports));
+
+            if (app.Ports.Length > 0)
+            {
+                var service = await serviceService.ReadService(app.Name, app.Id.ToNamespace());
+                if (service is null)
+                {
+                    await serviceService.CreateService(new ServiceModel(app.Name, app.Id.ToNamespace(), "ClusterIP",
+                        app.Ports, "TCP", app.Name));
+                }
+                else
+                {
+                    await serviceService.UpdateService(new ServiceModel(app.Name, app.Id.ToNamespace(), "ClusterIP",
+                        app.Ports, "TCP", app.Name));
+                }
+            }
         }
     }
 }

--- a/EvilGiraf/Service/KubernetesService.cs
+++ b/EvilGiraf/Service/KubernetesService.cs
@@ -4,7 +4,7 @@ using EvilGiraf.Model;
 
 namespace EvilGiraf.Service;
 
-public class KubernetesService(IDeploymentService deploymentService, INamespaceService namespaceService) : IKubernetesService
+public class KubernetesService(IDeploymentService deploymentService, INamespaceService namespaceService, ServiceService serviceService) : IKubernetesService
 {
     public async Task Deploy(Application app)
     {
@@ -14,6 +14,12 @@ public class KubernetesService(IDeploymentService deploymentService, INamespaceS
         {
             await deploymentService.CreateDeployment(new DeploymentModel(app.Name, app.Id.ToNamespace(), 1,
                 app.Link, app.Ports));
+
+            if(app.Ports.Length > 0)
+            {
+                await serviceService.CreateService(new ServiceModel(app.Name, app.Id.ToNamespace(), "ClusterIP",
+                    app.Ports, "TCP", app.Name));
+            }
         }
         else
         {

--- a/EvilGiraf/Service/KubernetesService.cs
+++ b/EvilGiraf/Service/KubernetesService.cs
@@ -13,12 +13,12 @@ public class KubernetesService(IDeploymentService deploymentService, INamespaceS
         if (deployment is null)
         {
             await deploymentService.CreateDeployment(new DeploymentModel(app.Name, app.Id.ToNamespace(), 1,
-                app.Link, []));
+                app.Link, app.Ports));
         }
         else
         {
             await deploymentService.UpdateDeployment(new DeploymentModel(app.Name, app.Id.ToNamespace(), 1,
-                app.Link, []));
+                app.Link, app.Ports));
         }
     }
 }

--- a/EvilGiraf/Service/KubernetesService.cs
+++ b/EvilGiraf/Service/KubernetesService.cs
@@ -4,7 +4,7 @@ using EvilGiraf.Model;
 
 namespace EvilGiraf.Service;
 
-public class KubernetesService(IDeploymentService deploymentService, INamespaceService namespaceService, ServiceService serviceService) : IKubernetesService
+public class KubernetesService(IDeploymentService deploymentService, INamespaceService namespaceService, IServiceService serviceService) : IKubernetesService
 {
     public async Task Deploy(Application app)
     {
@@ -28,17 +28,8 @@ public class KubernetesService(IDeploymentService deploymentService, INamespaceS
 
             if (app.Ports.Length > 0)
             {
-                var service = await serviceService.ReadService(app.Name, app.Id.ToNamespace());
-                if (service is null)
-                {
-                    await serviceService.CreateService(new ServiceModel(app.Name, app.Id.ToNamespace(), "ClusterIP",
-                        app.Ports, "TCP", app.Name));
-                }
-                else
-                {
-                    await serviceService.UpdateService(new ServiceModel(app.Name, app.Id.ToNamespace(), "ClusterIP",
-                        app.Ports, "TCP", app.Name));
-                }
+                await serviceService.CreateIfNotExistsService(new ServiceModel(app.Name, app.Id.ToNamespace(), "ClusterIP",
+                    app.Ports, "TCP", app.Name));
             }
         }
     }


### PR DESCRIPTION
This pull request introduces a new `IServiceService` interface and its implementation to manage Kubernetes services, along with corresponding unit tests. The changes also include updates to the `KubernetesService` to utilize the new `IServiceService` for creating and updating services.

### New Service Management:
* [`EvilGiraf/Interface/Kubernetes/IServiceService.cs`](diffhunk://#diff-154a1fe011319bca058fd1a594a36bc984957706085010305a2df267c353256dR1-R17): Added a new interface `IServiceService` for managing Kubernetes services, including methods for creating, reading, updating, deleting, and conditionally creating services.
* [`EvilGiraf/Service/Kubernetes/ServiceService.cs`](diffhunk://#diff-e9d17025f01909ae17699bde88d1c4a52d9172149cec375009b361089458a998R1-R68): Implemented the `IServiceService` interface with methods to interact with Kubernetes services, handling scenarios where namespaces or services may not exist.
* [`EvilGiraf/Model/ServiceModel.cs`](diffhunk://#diff-0aa974ab72340c363cb3c7b8f01ad0a7926b0672304bb9f29b0d77217030cd27R1-R34): Added a new `ServiceModel` record and extension methods to convert it to a Kubernetes `V1Service` object.

### Integration with Existing Services:
* [`EvilGiraf/Service/KubernetesService.cs`](diffhunk://#diff-b9268f1ad44d0a68c1a3b1f611de50d27abe34bc5e8ede7063e8f22fa0cd771dL7-R7): Updated the `KubernetesService` to use the `IServiceService` for creating and updating services when deploying applications. This ensures services are created or updated based on the application's ports. [[1]](diffhunk://#diff-b9268f1ad44d0a68c1a3b1f611de50d27abe34bc5e8ede7063e8f22fa0cd771dL7-R7) [[2]](diffhunk://#diff-b9268f1ad44d0a68c1a3b1f611de50d27abe34bc5e8ede7063e8f22fa0cd771dL16-R33)
* [`EvilGiraf/Program.cs`](diffhunk://#diff-a9d3f1f1b797f4245c728e66690b82cbc24c1a0660ff4791b7b27303f9976bdaR70): Registered the new `IServiceService` implementation in the dependency injection container.

### Unit Tests:
* [`EvilGiraf.Tests/ServiceTests.cs`](diffhunk://#diff-cac5fcbe59c48b2342c47ac6bd7241edd5f8bf52d9f44ed7df53956ec57905afR1-R274): Added comprehensive unit tests for the `ServiceService` to verify the creation, reading, updating, deleting, and conditional creation of Kubernetes services.
* [`EvilGiraf.Tests/KubernetesTests.cs`](diffhunk://#diff-da762d2b58ec36719650e6e7d0b91c4beda8afc6f1f35b4dd69d369b1cd40fd0R2): Updated the `KubernetesTests` to include the new `IServiceService` dependency in the `KubernetesService` constructor. [[1]](diffhunk://#diff-da762d2b58ec36719650e6e7d0b91c4beda8afc6f1f35b4dd69d369b1cd40fd0R2) [[2]](diffhunk://#diff-da762d2b58ec36719650e6e7d0b91c4beda8afc6f1f35b4dd69d369b1cd40fd0L19-R20)

### Integration Tests:
* [`EvilGiraf.IntegrationTests/DeploymentControllerTests.cs`](diffhunk://#diff-2b8550fdb2e5c7611e33b2349f1c866a5f3e921d835d042a1e493d32ee5d4e6fR26-R81): Added and updated integration tests to ensure the `Deploy` methods handle services correctly, including scenarios where services are created or updated. [[1]](diffhunk://#diff-2b8550fdb2e5c7611e33b2349f1c866a5f3e921d835d042a1e493d32ee5d4e6fR26-R81) [[2]](diffhunk://#diff-2b8550fdb2e5c7611e33b2349f1c866a5f3e921d835d042a1e493d32ee5d4e6fR105-R108) [[3]](diffhunk://#diff-2b8550fdb2e5c7611e33b2349f1c866a5f3e921d835d042a1e493d32ee5d4e6fR118-R122) [[4]](diffhunk://#diff-2b8550fdb2e5c7611e33b2349f1c866a5f3e921d835d042a1e493d32ee5d4e6fR171-R174) [[5]](diffhunk://#diff-2b8550fdb2e5c7611e33b2349f1c866a5f3e921d835d042a1e493d32ee5d4e6fR194-R198)

closes #98 