### PR TITLE
Feat/app name without spaces

### DIFF
--- a/EvilGiraf.IntegrationTests/ApplicationControllerTests.cs
+++ b/EvilGiraf.IntegrationTests/ApplicationControllerTests.cs
@@ -60,6 +60,19 @@ public class ApplicationControllerTests : AuthenticatedTestBase
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
+    
+    [Fact]
+    public async Task CreateWithNameContainingSpaces_ShouldReturnBadRequest()
+    {
+        // Arrange
+        var createRequest = new ApplicationCreateDto("test application", ApplicationType.Docker, "docker.io/test-application:latest", "1.0.0", [22]);
+
+        // Act
+        var response = await Client.PostAsJsonAsync("/api/application", createRequest);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
 
     [Fact]
     public async Task Get_ShouldReturnApplication()
@@ -152,6 +165,31 @@ public class ApplicationControllerTests : AuthenticatedTestBase
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
 
+    [Fact]
+    public async Task UpdateNameAppWithSpaces_ShouldReturnBadRequest()
+    {
+        // Arrange
+        var application = new Application
+        {
+            Name = "valid-name",
+            Type = ApplicationType.Docker,
+            Link = "docker.io/valid-name:latest",
+            Version = "1.0.0",
+            Ports = [22]
+        };
+
+        _dbContext.Applications.Add(application);
+        await _dbContext.SaveChangesAsync();
+
+        var updateRequest = new ApplicationUpdateDto("invalid name", ApplicationType.Git, "k8s.io/invalid-name:latest", "2.0.0", [23]);
+
+        // Act
+        var response = await Client.PatchAsJsonAsync($"/api/application/{application.Id}", updateRequest);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+    
     [Fact]
     public async Task Update_ShouldUpdateApplication()
     {

--- a/EvilGiraf.IntegrationTests/ApplicationControllerTests.cs
+++ b/EvilGiraf.IntegrationTests/ApplicationControllerTests.cs
@@ -64,14 +64,19 @@ public class ApplicationControllerTests : AuthenticatedTestBase
     [Fact]
     public async Task CreateWithNameContainingSpaces_ShouldReturnBadRequest()
     {
-        // Arrange
-        var createRequest = new ApplicationCreateDto("test application", ApplicationType.Docker, "docker.io/test-application:latest", "1.0.0", [22]);
+        
+        var invalidNames = new[] { null, "", "invalid name" };
+        foreach (var name in invalidNames)
+        {   
+            // Arrange
+            var createRequest = new ApplicationCreateDto("test application", ApplicationType.Docker, "docker.io/test-application:latest", "1.0.0", [22]);
 
-        // Act
-        var response = await Client.PostAsJsonAsync("/api/application", createRequest);
+            // Act
+            var response = await Client.PostAsJsonAsync("/api/application", createRequest);
 
-        // Assert
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+            // Assert
+            response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        }
     }
 
     [Fact]
@@ -181,13 +186,17 @@ public class ApplicationControllerTests : AuthenticatedTestBase
         _dbContext.Applications.Add(application);
         await _dbContext.SaveChangesAsync();
 
-        var updateRequest = new ApplicationUpdateDto("invalid name", ApplicationType.Git, "k8s.io/invalid-name:latest", "2.0.0", [23]);
+        var invalidNames = new[] { "", "invalid name" }; //null value wasn't added because it's DTO work
+        foreach (var name in invalidNames)
+        {
+            var updateRequest = new ApplicationUpdateDto(name, ApplicationType.Git, "k8s.io/invalid-name:latest", "2.0.0", [23]);
 
-        // Act
-        var response = await Client.PatchAsJsonAsync($"/api/application/{application.Id}", updateRequest);
+            // Act
+            var response = await Client.PatchAsJsonAsync($"/api/application/{application.Id}", updateRequest);
 
-        // Assert
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+            // Assert
+            response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        }
     }
     
     [Fact]

--- a/EvilGiraf/Controller/ApplicationController.cs
+++ b/EvilGiraf/Controller/ApplicationController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using EvilGiraf.Dto;
 using EvilGiraf.Extensions;
 using Microsoft.AspNetCore.Authorization;
+using System.Linq;
 
 namespace EvilGiraf.Controller;
 
@@ -16,6 +17,9 @@ public class ApplicationController(IApplicationService applicationService) : Con
     public async  Task<IActionResult> Create([FromBody] ApplicationCreateDto request)
     {
         var application = await applicationService.CreateApplication(request);
+        
+        if (application.Name.Any(char.IsWhiteSpace))
+            return BadRequest("Application name cannot contain spaces");
 
         return Created($"", application.ToDto());
     }
@@ -54,6 +58,9 @@ public class ApplicationController(IApplicationService applicationService) : Con
 
         if(application is null)
             return NotFound($"Application {id} not found");
+        
+        if (application.Name.Any(char.IsWhiteSpace))
+            return BadRequest("Application name cannot contain spaces");
 
         return Ok(application.ToDto());
     }

--- a/EvilGiraf/Controller/ApplicationController.cs
+++ b/EvilGiraf/Controller/ApplicationController.cs
@@ -18,8 +18,8 @@ public class ApplicationController(IApplicationService applicationService) : Con
     {
         var application = await applicationService.CreateApplication(request);
         
-        if (application.Name.Any(char.IsWhiteSpace))
-            return BadRequest("Application name cannot contain spaces");
+        if (string.IsNullOrEmpty(application.Name) || application.Name.Any(char.IsWhiteSpace))
+            return BadRequest("Application name cannot be null, empty, or contain spaces");
 
         return Created($"", application.ToDto());
     }
@@ -59,8 +59,8 @@ public class ApplicationController(IApplicationService applicationService) : Con
         if(application is null)
             return NotFound($"Application {id} not found");
         
-        if (application.Name.Any(char.IsWhiteSpace))
-            return BadRequest("Application name cannot contain spaces");
+        if (string.IsNullOrEmpty(application.Name) || application.Name.Any(char.IsWhiteSpace))
+            return BadRequest("Application name cannot be null, empty, or contain spaces");
 
         return Ok(application.ToDto());
     }


### PR DESCRIPTION
This pull request introduces several changes to ensure that application names are validated to prevent null, empty, or whitespace-containing names in both the creation and update processes. The changes include new test cases to verify these validations and updates to the controller methods to enforce the new rules.

### Validation Enhancements:

* [`EvilGiraf/Controller/ApplicationController.cs`](diffhunk://#diff-bc696ba179cc89bff2b9790a26d4e4f57733d34afb290ff377446fa4577f6b92R21-R23): Added validation checks in the `Create` and `Update` methods to ensure that application names are not null, empty, or contain spaces. [[1]](diffhunk://#diff-bc696ba179cc89bff2b9790a26d4e4f57733d34afb290ff377446fa4577f6b92R21-R23) [[2]](diffhunk://#diff-bc696ba179cc89bff2b9790a26d4e4f57733d34afb290ff377446fa4577f6b92R62-R64)

### New Test Cases:

* [`EvilGiraf.IntegrationTests/ApplicationControllerTests.cs`](diffhunk://#diff-d41f11456c621976336f13cf3d5fd3b37b8b6fa73ae592bb6cb9e2c180b36a1bR64-R81): Added `CreateWithNameContainingSpaces_ShouldReturnBadRequest` test to verify that creating an application with invalid names returns a `BadRequest` status.
* [`EvilGiraf.IntegrationTests/ApplicationControllerTests.cs`](diffhunk://#diff-d41f11456c621976336f13cf3d5fd3b37b8b6fa73ae592bb6cb9e2c180b36a1bR173-R201): Added `UpdateNameAppWithSpaces_ShouldReturnBadRequest` test to ensure that updating an application with invalid names returns a `BadRequest` status.

### Codebase Maintenance:

* [`EvilGiraf/Controller/ApplicationController.cs`](diffhunk://#diff-bc696ba179cc89bff2b9790a26d4e4f57733d34afb290ff377446fa4577f6b92R6): Added the `System.Linq` namespace to support the validation logic.

closes #136 