### PR TITLE
chore: add polling mechanism for deployment status updates

### DIFF
--- a/EvilGiraf.Front/Dockerfile
+++ b/EvilGiraf.Front/Dockerfile
@@ -10,7 +10,7 @@ RUN npm run build
 FROM nginx:alpine
 EXPOSE 80
 
-COPY --from=build /app/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/dist /usr/share/nginx/html
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/EvilGiraf.Front/src/lib/api.ts
+++ b/EvilGiraf.Front/src/lib/api.ts
@@ -95,9 +95,15 @@ export const api = {
       }
     },
     
-    status: async (id: number): Promise<DeployResponse> => {
+    status: async (id: number): Promise<DeployResponse | null> => {
       const response = await fetch(`${API_URL}/deploy/${id}`, { headers: getHeaders() });
-      return handleResponse(response);
+      if (!response.ok) {
+        throw new ApiError(response.status, await response.text());
+      }
+      if (response.status === 204) {
+        return null;
+      }
+      return response.json();
     },
   },
 };

--- a/EvilGiraf.Front/src/pages/ApplicationDetails.tsx
+++ b/EvilGiraf.Front/src/pages/ApplicationDetails.tsx
@@ -32,8 +32,18 @@ export function ApplicationDetails() {
   const deployMutation = useMutation(
     () => api.deployments.deploy(Number(id)),
     {
-      onSuccess: () => {
-        queryClient.invalidateQueries(['deployStatus', id]);
+      onSuccess: async () => {
+        let attempts = 0;
+        const maxAttempts = 30;
+        while (attempts < maxAttempts) {
+          await queryClient.invalidateQueries(['deployStatus', id]);
+          const status = await api.deployments.status(Number(id));
+          if (status !== null) {
+            break;
+          }
+          attempts++;
+          await new Promise(resolve => setTimeout(resolve, 2000));
+        }
       },
     }
   );
@@ -41,8 +51,18 @@ export function ApplicationDetails() {
   const undeployMutation = useMutation(
     () => api.deployments.undeploy(Number(id)),
     {
-      onSuccess: () => {
-        queryClient.invalidateQueries(['deployStatus', id]);
+      onSuccess: async () => {
+        let attempts = 0;
+        const maxAttempts = 30;
+        while (attempts < maxAttempts) {
+          await queryClient.invalidateQueries(['deployStatus', id]);
+          const status = await api.deployments.status(Number(id));
+          if (status === null) {
+            break;
+          }
+          attempts++;
+          await new Promise(resolve => setTimeout(resolve, 2000));
+        }
       },
     }
   );


### PR DESCRIPTION
Enhanced deployment and undeployment mutations to poll for status updates until success or a defined timeout. This ensures the frontend accurately reflects the deployment state by repeatedly querying the API. Added handling for empty deployment status responses to improve resilience.