### PR TITLE
refactor: replace multiple ports with single port in Application

### DIFF
--- a/EvilGiraf.IntegrationTests/ApplicationControllerTests.cs
+++ b/EvilGiraf.IntegrationTests/ApplicationControllerTests.cs
@@ -4,7 +4,6 @@ using EvilGiraf.Dto;
 using EvilGiraf.Model;
 using EvilGiraf.Service;
 using FluentAssertions;
-using Microsoft.EntityFrameworkCore;
 
 namespace EvilGiraf.IntegrationTests;
 
@@ -21,7 +20,7 @@ public class ApplicationControllerTests : AuthenticatedTestBase
     public async Task Create_ShouldCreateApplication()
     {
         // Arrange
-        var createRequest = new ApplicationCreateDto("test-application", ApplicationType.Docker, "docker.io/test-application:latest", "1.0.0", [22]);
+        var createRequest = new ApplicationCreateDto("test-application", ApplicationType.Docker, "docker.io/test-application:latest", "1.0.0", 22);
 
         // Act
         var response = await Client.PostAsJsonAsync("/api/application", createRequest);
@@ -36,7 +35,7 @@ public class ApplicationControllerTests : AuthenticatedTestBase
         application.Link.Should().Be(createRequest.Link);
         application.Version.Should().Be(createRequest.Version);
         application.Id.Should().NotBe(0);
-        application.Ports.Should().BeEquivalentTo(createRequest.Ports);
+        application.Port.Should().Be(createRequest.Port);
 
         // Verify the application was saved to the database
         var savedApplication = await _dbContext.Applications.FindAsync(application.Id);
@@ -45,14 +44,14 @@ public class ApplicationControllerTests : AuthenticatedTestBase
         savedApplication.Type.Should().Be(createRequest.Type);
         savedApplication.Link.Should().Be(createRequest.Link);
         savedApplication.Version.Should().Be(createRequest.Version);
-        savedApplication.Ports.Should().BeEquivalentTo(createRequest.Ports);
+        savedApplication.Port.Should().Be(createRequest.Port);
     }
 
     [Fact]
     public async Task CreateWithWrongBody_ShouldReturnBadRequest()
     {
         // Arrange
-        var createRequest = new ApplicationCreateDto(null!, ApplicationType.Docker, "docker.io/test-application:latest", "1.0.0", [22]);
+        var createRequest = new ApplicationCreateDto(null!, ApplicationType.Docker, "docker.io/test-application:latest", "1.0.0", 22);
 
         // Act
         var response = await Client.PostAsJsonAsync("/api/application", createRequest);
@@ -71,7 +70,7 @@ public class ApplicationControllerTests : AuthenticatedTestBase
             Type = ApplicationType.Docker,
             Link = "docker.io/test-application:latest",
             Version = "1.0.0",
-            Ports = [22]
+            Port = 22
         };
 
         _dbContext.Applications.Add(application);
@@ -90,7 +89,7 @@ public class ApplicationControllerTests : AuthenticatedTestBase
         applicationDto.Link.Should().Be(application.Link);
         applicationDto.Version.Should().Be(application.Version);
         applicationDto.Id.Should().Be(application.Id);
-        applicationDto.Ports.Should().BeEquivalentTo(application.Ports);
+        applicationDto.Port.Should().Be(application.Port);
     }
 
     [Fact]
@@ -103,7 +102,7 @@ public class ApplicationControllerTests : AuthenticatedTestBase
             Type = ApplicationType.Docker,
             Link = "docker.io/test-application:latest",
             Version = "1.0.0",
-            Ports = [22]
+            Port = 22
         };
 
         _dbContext.Applications.Add(application);
@@ -126,7 +125,7 @@ public class ApplicationControllerTests : AuthenticatedTestBase
             Type = ApplicationType.Docker,
             Link = "docker.io/test-application:latest",
             Version = "1.0.0",
-            Ports = [22]
+            Port = 22
         };
 
         _dbContext.Applications.Add(application);
@@ -162,13 +161,13 @@ public class ApplicationControllerTests : AuthenticatedTestBase
             Type = ApplicationType.Docker,
             Link = "docker.io/test-application:latest",
             Version = "1.0.0",
-            Ports = [22]
+            Port = 22
         };
 
         _dbContext.Applications.Add(application);
         await _dbContext.SaveChangesAsync();
 
-        var updateRequest = new ApplicationUpdateDto("updated-application", ApplicationType.Git, "k8s.io/updated-application:latest", "2.0.0", [23]);
+        var updateRequest = new ApplicationUpdateDto("updated-application", ApplicationType.Git, "k8s.io/updated-application:latest", "2.0.0", 23);
 
         // Act
         var response = await Client.PatchAsJsonAsync($"/api/application/{application.Id}", updateRequest);
@@ -184,7 +183,7 @@ public class ApplicationControllerTests : AuthenticatedTestBase
         updatedApplication.Link.Should().Be(updateRequest.Link);
         updatedApplication.Version.Should().Be(updateRequest.Version);
         updatedApplication.Id.Should().Be(application.Id);
-        updatedApplication.Ports.Should().BeEquivalentTo(updateRequest.Ports);
+        updatedApplication.Port.Should().Be(updateRequest.Port);
 
         // Verify the application was updated in the database
         response = await Client.GetAsync($"/api/application/{application.Id}");
@@ -196,14 +195,14 @@ public class ApplicationControllerTests : AuthenticatedTestBase
         savedApplication.Type.Should().Be(updateRequest.Type);
         savedApplication.Link.Should().Be(updateRequest.Link);
         savedApplication.Version.Should().Be(updateRequest.Version);
-        savedApplication.Ports.Should().BeEquivalentTo(updateRequest.Ports);
+        savedApplication.Port.Should().Be(updateRequest.Port);
     }
 
     [Fact]
     public async Task UpdateWithNonExistingId_ShouldReturnNotFound()
     {
         // Arrange
-        var updateRequest = new ApplicationUpdateDto("updated-application", ApplicationType.Git, "k8s.io/updated-application:latest", "2.0.0", [22]);
+        var updateRequest = new ApplicationUpdateDto("updated-application", ApplicationType.Git, "k8s.io/updated-application:latest", "2.0.0", 22);
 
         // Act
         var response = await Client.PatchAsJsonAsync($"/api/application/{999}", updateRequest);
@@ -222,7 +221,7 @@ public class ApplicationControllerTests : AuthenticatedTestBase
             Type = ApplicationType.Docker,
             Link = "docker.io/test-application:latest",
             Version = "1.0.0",
-            Ports = [22]
+            Port = 22
         };
 
         _dbContext.Applications.Add(application);
@@ -244,7 +243,7 @@ public class ApplicationControllerTests : AuthenticatedTestBase
         updatedApplication.Link.Should().Be(application.Link);
         updatedApplication.Version.Should().Be(application.Version);
         updatedApplication.Id.Should().Be(application.Id);
-        updatedApplication.Ports.Should().BeEquivalentTo(application.Ports);
+        updatedApplication.Port.Should().Be(application.Port);
 
         // Verify the application was updated in the database
         response = await Client.GetAsync($"/api/application/{application.Id}");
@@ -256,7 +255,7 @@ public class ApplicationControllerTests : AuthenticatedTestBase
         savedApplication.Type.Should().Be(application.Type);
         savedApplication.Link.Should().Be(application.Link);
         savedApplication.Version.Should().Be(application.Version);
-        savedApplication.Ports.Should().BeEquivalentTo(application.Ports);
+        savedApplication.Port.Should().Be(application.Port);
     }
 
     [Fact]
@@ -270,7 +269,7 @@ public class ApplicationControllerTests : AuthenticatedTestBase
                 Type = ApplicationType.Docker,
                 Link = "docker.io/test-application-1:latest",
                 Version = "1.0.0",
-                Ports = [22]
+                Port = 22
             },
             new()
             {
@@ -278,7 +277,7 @@ public class ApplicationControllerTests : AuthenticatedTestBase
                 Type = ApplicationType.Git,
                 Link = "k8s.io/test-application-2:latest",
                 Version = "2.0.0",
-                Ports = [22]
+                Port = 22
             }
         };
 
@@ -300,7 +299,7 @@ public class ApplicationControllerTests : AuthenticatedTestBase
     }
 
     [Fact]
-    public async Task CreateWithNoPorts_ShouldReturnApplication()
+    public async Task CreateWithNoPort_ShouldReturnApplication()
     {
         // Arrange
         var createRequest = new ApplicationCreateDto("test-application", ApplicationType.Docker, "docker.io/test-application:latest", "1.0.0", null);
@@ -318,7 +317,7 @@ public class ApplicationControllerTests : AuthenticatedTestBase
         application.Link.Should().Be(createRequest.Link);
         application.Version.Should().Be(createRequest.Version);
         application.Id.Should().NotBe(0);
-        application.Ports.Should().BeEmpty();
+        application.Port.Should().BeNull();
 
         // Verify the application was saved to the database
         var savedApplication = await _dbContext.Applications.FindAsync(application.Id);
@@ -327,37 +326,6 @@ public class ApplicationControllerTests : AuthenticatedTestBase
         savedApplication.Type.Should().Be(createRequest.Type);
         savedApplication.Link.Should().Be(createRequest.Link);
         savedApplication.Version.Should().Be(createRequest.Version);
-        savedApplication.Ports.Should().BeEmpty();
-    }
-
-    [Fact]
-    public async Task CreateWithMultiplePorts_ShouldReturnApplication()
-    {
-        // Arrange
-        var createRequest = new ApplicationCreateDto("test-application", ApplicationType.Docker, "docker.io/test-application:latest", "1.0.0", [22, 80]);
-
-        // Act
-        var response = await Client.PostAsJsonAsync("/api/application", createRequest);
-
-        // Assert
-        response.StatusCode.Should().Be(HttpStatusCode.Created);
-        var application = await response.Content.ReadFromJsonAsync<Application>();
-        
-        application.Should().NotBeNull();
-        application!.Name.Should().Be(createRequest.Name);
-        application.Type.Should().Be(createRequest.Type);
-        application.Link.Should().Be(createRequest.Link);
-        application.Version.Should().Be(createRequest.Version);
-        application.Id.Should().NotBe(0);
-        application.Ports.Should().BeEquivalentTo(createRequest.Ports);
-
-        // Verify the application was saved to the database
-        var savedApplication = await _dbContext.Applications.FindAsync(application.Id);
-        savedApplication.Should().NotBeNull();
-        savedApplication!.Name.Should().Be(createRequest.Name);
-        savedApplication.Type.Should().Be(createRequest.Type);
-        savedApplication.Link.Should().Be(createRequest.Link);
-        savedApplication.Version.Should().Be(createRequest.Version);
-        savedApplication.Ports.Should().BeEquivalentTo(createRequest.Ports);
+        savedApplication.Port.Should().BeNull();
     }
 }

--- a/EvilGiraf.IntegrationTests/DeploymentControllerTests.cs
+++ b/EvilGiraf.IntegrationTests/DeploymentControllerTests.cs
@@ -33,7 +33,7 @@ public class DeploymentControllerTests : AuthenticatedTestBase
             Type = ApplicationType.Docker,
             Link = "docker.io/test-app:latest",
             Version = "1.0.0",
-            Ports = [22]
+            Port = 22
         };
         var deployment = new HttpOperationResponse<V1Deployment>
         {
@@ -89,7 +89,7 @@ public class DeploymentControllerTests : AuthenticatedTestBase
             Type = ApplicationType.Docker,
             Link = "docker.io/test-app:latest",
             Version = "1.0.0",
-            Ports = [22]
+            Port = 22
         };
         var deployment = new HttpOperationResponse<V1Deployment>
         {
@@ -154,7 +154,7 @@ public class DeploymentControllerTests : AuthenticatedTestBase
             Type = ApplicationType.Docker,
             Link = "docker.io/test-app:latest",
             Version = "1.0.0",
-            Ports = [22]
+            Port = 22
         };
 
         var deployment = new HttpOperationResponse<V1Deployment>
@@ -230,7 +230,7 @@ public class DeploymentControllerTests : AuthenticatedTestBase
             Type = ApplicationType.Docker,
             Link = "docker.io/test-app:latest",
             Version = "1.0.0",
-            Ports = [22]
+            Port = 22
         };
 
         var deployment = new HttpOperationResponse<V1Deployment>
@@ -273,7 +273,7 @@ public class DeploymentControllerTests : AuthenticatedTestBase
             Type = ApplicationType.Docker,
             Link = "docker.io/test-app:latest",
             Version = "1.0.0",
-            Ports = [22]
+            Port = 22
         };
         
         var httpException = new HttpOperationException
@@ -316,8 +316,8 @@ public class DeploymentControllerTests : AuthenticatedTestBase
     {
         var applications = new List<Application>
         {
-            new() { Name = "app1", Type = ApplicationType.Docker, Link = "docker.io/app1:latest", Version = "1.0.0", Ports = [22] },
-            new() { Name = "app2", Type = ApplicationType.Git, Link = "k8s.io/app2:latest", Version = "2.0.0", Ports = [] }
+            new() { Name = "app1", Type = ApplicationType.Docker, Link = "docker.io/app1:latest", Version = "1.0.0", Port = 22 },
+            new() { Name = "app2", Type = ApplicationType.Git, Link = "k8s.io/app2:latest", Version = "2.0.0", Port = null }
         };
 
         _dbContext.Applications.AddRange(applications);
@@ -341,8 +341,8 @@ public class DeploymentControllerTests : AuthenticatedTestBase
         // Arrange
         var applications = new List<Application>
         {
-            new() { Name = "app1", Type = ApplicationType.Docker, Link = "docker.io/app1:latest", Version = "1.0.0", Ports = [22] },
-            new() { Name = "app2", Type = ApplicationType.Git, Link = "k8s.io/app2:latest", Version = "2.0.0", Ports = [] }
+            new() { Name = "app1", Type = ApplicationType.Docker, Link = "docker.io/app1:latest", Version = "1.0.0", Port = 22 },
+            new() { Name = "app2", Type = ApplicationType.Git, Link = "k8s.io/app2:latest", Version = "2.0.0", Port = null }
         };
 
         _dbContext.Applications.AddRange(applications);
@@ -377,7 +377,7 @@ public class DeploymentControllerTests : AuthenticatedTestBase
             Type = ApplicationType.Docker,
             Link = "docker.io/test-app:latest",
             Version = "1.0.0",
-            Ports = [22]
+            Port = 22
         };
 
         _dbContext.Applications.Add(application);
@@ -418,7 +418,7 @@ public class DeploymentControllerTests : AuthenticatedTestBase
             Type = ApplicationType.Git, 
             Link = "https://github.com/example/repo.git", 
             Version = "1.0.0", 
-            Ports = [] 
+            Port = null
         };
         
         _dbContext.Applications.Add(gitApp);
@@ -480,7 +480,7 @@ public class DeploymentControllerTests : AuthenticatedTestBase
             Type = ApplicationType.Git, 
             Link = "https://github.com/example/repo.git", 
             Version = "1.0.0", 
-            Ports = [] 
+            Port = null
         };
         
         _dbContext.Applications.Add(gitApp);
@@ -547,7 +547,7 @@ public class DeploymentControllerTests : AuthenticatedTestBase
             Type = ApplicationType.Git, 
             Link = "https://github.com/example/repo.git", 
             Version = "1.0.0", 
-            Ports = [80] 
+            Port = 80
         };
         
         _dbContext.Applications.Add(gitApp);
@@ -581,8 +581,8 @@ public class DeploymentControllerTests : AuthenticatedTestBase
         // Arrange
         var applications = new List<Application>
         {
-            new() { Name = "docker-app", Type = ApplicationType.Docker, Link = "docker.io/app:latest", Version = "1.0.0", Ports = [80] },
-            new() { Name = "git-app", Type = ApplicationType.Git, Link = "https://github.com/example/repo.git", Version = "1.0.0", Ports = [8080] }
+            new() { Name = "docker-app", Type = ApplicationType.Docker, Link = "docker.io/app:latest", Version = "1.0.0", Port = 80 },
+            new() { Name = "git-app", Type = ApplicationType.Git, Link = "https://github.com/example/repo.git", Version = "1.0.0", Port = 8080 }
         };
 
         _dbContext.Applications.AddRange(applications);
@@ -617,7 +617,7 @@ public class DeploymentControllerTests : AuthenticatedTestBase
             Type = ApplicationType.Git, 
             Link = "https://github.com/example/broken-repo.git", 
             Version = "1.0.0", 
-            Ports = [80] 
+            Port = 80
         };
         
         _dbContext.Applications.Add(gitApp);

--- a/EvilGiraf.Tests/ApplicationTests.cs
+++ b/EvilGiraf.Tests/ApplicationTests.cs
@@ -20,7 +20,7 @@ public class ApplicationTests
     public async Task CreateApplication_ShouldCreateAndReturnNewApplication()
     {
         // Arrange
-        var application = new ApplicationCreateDto("TestApp", ApplicationType.Docker, "https://test.com", "1.0.0", [22]);
+        var application = new ApplicationCreateDto("TestApp", ApplicationType.Docker, "https://test.com", "1.0.0", 22);
 
         // Act
         var result = await _applicationService.CreateApplication(application);
@@ -31,14 +31,14 @@ public class ApplicationTests
         result.Type.Should().Be(application.Type);
         result.Link.Should().Be(application.Link);
         result.Version.Should().Be(application.Version);
-        result.Ports.Should().BeEquivalentTo(application.Ports);
+        result.Port.Should().Be(application.Port);
     }
 
     [Fact]
     public async Task GetApplication_ShouldReturnApplication()
     {
         // Arrange
-        var application = new ApplicationCreateDto("TestApp", ApplicationType.Docker, "https://test.com", "1.0.0", [22]);
+        var application = new ApplicationCreateDto("TestApp", ApplicationType.Docker, "https://test.com", "1.0.0", 22);
         var createdApplication = await _applicationService.CreateApplication(application);
 
         // Act
@@ -51,7 +51,7 @@ public class ApplicationTests
         result.Type.Should().Be(application.Type);
         result.Link.Should().Be(application.Link);
         result.Version.Should().Be(application.Version);
-        result.Ports.Should().BeEquivalentTo(application.Ports);
+        result.Port.Should().Be(application.Port);
     }
 
     [Fact]
@@ -68,7 +68,7 @@ public class ApplicationTests
     public async Task DeleteApplication_ShouldDeleteApplication()
     {
         // Arrange
-        var application = new ApplicationCreateDto("TestApp", ApplicationType.Docker, "https://test.com", "1.0.0", [22]);
+        var application = new ApplicationCreateDto("TestApp", ApplicationType.Docker, "https://test.com", "1.0.0", 22);
         var createdApplication = await _applicationService.CreateApplication(application);
 
         // Act
@@ -96,11 +96,11 @@ public class ApplicationTests
     {
         // Arrange
         var applicationDto = new ApplicationCreateDto(
-            "TestApp", ApplicationType.Docker, "https://test.com", "1.0.0", [22]);
+            "TestApp", ApplicationType.Docker, "https://test.com", "1.0.0", 22);
         var createdApplication = await _applicationService.CreateApplication(applicationDto);
 
         var updatedApplicationDto = new ApplicationUpdateDto(
-            "UpdatedTestApp", ApplicationType.Docker, "https://updatedtest.com", "2.0.0", [23]);
+            "UpdatedTestApp", ApplicationType.Docker, "https://updatedtest.com", "2.0.0", 23);
 
         // Act
         var result = await _applicationService.UpdateApplication(createdApplication.Id, updatedApplicationDto);
@@ -112,7 +112,7 @@ public class ApplicationTests
         result.Type.Should().Be(updatedApplicationDto.Type);
         result.Link.Should().Be(updatedApplicationDto.Link);
         result.Version.Should().Be(updatedApplicationDto.Version);
-        result.Ports.Should().BeEquivalentTo(updatedApplicationDto.Ports);
+        result.Port.Should().Be(updatedApplicationDto.Port);
     }
     
     [Fact]
@@ -120,7 +120,7 @@ public class ApplicationTests
     {
         // Arrange
         var applicationDto = new ApplicationCreateDto(
-            "TestApp", ApplicationType.Docker, "https://test.com", "1.0.0", [22]);
+            "TestApp", ApplicationType.Docker, "https://test.com", "1.0.0", 22);
         var createdApplication = await _applicationService.CreateApplication(applicationDto);
 
         var updatedApplicationDto = new ApplicationUpdateDto(
@@ -136,7 +136,7 @@ public class ApplicationTests
         result.Type.Should().Be(applicationDto.Type);
         result.Link.Should().Be(applicationDto.Link);
         result.Version.Should().Be(applicationDto.Version);
-        result.Ports.Should().BeEquivalentTo(applicationDto.Ports);
+        result.Port.Should().Be(applicationDto.Port);
     }
     
     [Fact]
@@ -144,7 +144,7 @@ public class ApplicationTests
     {
         // Arrange
         var updatedApplicationDto = new ApplicationUpdateDto(
-            "UpdatedTestApp", ApplicationType.Docker, "https://updatedtest.com", "2.0.0", [22]);
+            "UpdatedTestApp", ApplicationType.Docker, "https://updatedtest.com", "2.0.0", 22);
 
         // Act
         var result = await _applicationService.UpdateApplication(999, updatedApplicationDto);
@@ -163,9 +163,9 @@ public class ApplicationTests
             await _applicationService.DeleteApplication(app.Id);
         }
 
-        var application1 = new ApplicationCreateDto("TestApp1", ApplicationType.Docker, "https://test.com", "1.0.0", [22]);
-        var application2 = new ApplicationCreateDto("TestApp2", ApplicationType.Docker, "https://test.com", "1.0.0", [22]);
-        var application3 = new ApplicationCreateDto("TestApp3", ApplicationType.Docker, "https://test.com", "1.0.0", [22]);
+        var application1 = new ApplicationCreateDto("TestApp1", ApplicationType.Docker, "https://test.com", "1.0.0", 22);
+        var application2 = new ApplicationCreateDto("TestApp2", ApplicationType.Docker, "https://test.com", "1.0.0", 22);
+        var application3 = new ApplicationCreateDto("TestApp3", ApplicationType.Docker, "https://test.com", "1.0.0", 22);
 
         await _applicationService.CreateApplication(application1);
         await _applicationService.CreateApplication(application2);

--- a/EvilGiraf.Tests/DeploymentTests.cs
+++ b/EvilGiraf.Tests/DeploymentTests.cs
@@ -13,8 +13,8 @@ namespace EvilGiraf.Tests;
 
 public class DeploymentTests
 {
-    public IDeploymentService DeploymentService { get; }
-    public IKubernetes Client { get; }
+    private IDeploymentService DeploymentService { get; }
+    private IKubernetes Client { get; }
 
     public DeploymentTests()
     {
@@ -54,7 +54,7 @@ public class DeploymentTests
             "default",
             1,
             "nginx",
-            [80]
+            80
         );
         var result = await DeploymentService.CreateDeployment(model);
         result.Should().NotBeNull();
@@ -65,8 +65,10 @@ public class DeploymentTests
     [Fact]
     public async Task CreateDeployment_with_namespace_not_exist_Should_Return_Deployment()
     {
-        var response = new HttpOperationException();
-        response.Response = new HttpResponseMessageWrapper(new HttpResponseMessage(HttpStatusCode.NotFound), string.Empty);
+        var response = new HttpOperationException
+        {
+            Response = new HttpResponseMessageWrapper(new HttpResponseMessage(HttpStatusCode.NotFound), string.Empty)
+        };
         Client.CoreV1.ReadNamespaceWithHttpMessagesAsync(Arg.Any<string>()).Throws(response);
         Client.CoreV1.CreateNamespaceWithHttpMessagesAsync(Arg.Any<V1Namespace>()).Returns(new HttpOperationResponse<V1Namespace>());
         
@@ -75,7 +77,7 @@ public class DeploymentTests
             "default",
             1,
             "nginx",
-            [80]
+            80
         );
         var result = await DeploymentService.CreateDeployment(model);
         result.Should().NotBeNull();
@@ -164,7 +166,7 @@ public class DeploymentTests
             "default",
             1,
             "nginx",
-            [80]
+            80
         );
         var result = await DeploymentService.UpdateDeployment(model);
         result.Should().NotBeNull();
@@ -180,7 +182,7 @@ public class DeploymentTests
             "default",
             1,
             "nginx",
-            [80]
+            80
         );
         var httpException = new HttpOperationException
         {

--- a/EvilGiraf.Tests/GitBuildTests.cs
+++ b/EvilGiraf.Tests/GitBuildTests.cs
@@ -38,7 +38,7 @@ public class GitBuildTests
             Name = "test-app",
             Version = "1.0",
             Link = "github.com/test/repo",
-            Ports = [8080]
+            Port = 8080
         };
 
         var expectedImageUrl = $"{RegistryUrl}/evilgiraf-{app.Id}:{app.Version}";
@@ -83,7 +83,7 @@ public class GitBuildTests
             Name = "test-app",
             Version = "1.0",
             Link = "github.com/test/repo",
-            Ports = [8080]
+            Port = 8080
         };
         var ns = app.Id.ToNamespace();
 
@@ -120,7 +120,7 @@ public class GitBuildTests
             Name = "test-app",
             Version = "1.0",
             Link = "github.com/test/repo",
-            Ports = [8080]
+            Port = 8080
         };
         var ns = app.Id.ToNamespace();
 
@@ -162,7 +162,7 @@ public class GitBuildTests
             Name = "test-app",
             Version = "1.0",
             Link = "github.com/test/repo",
-            Ports = [8080]
+            Port = 8080
         };
 
         var createdJob = new V1Job();
@@ -209,7 +209,7 @@ public class GitBuildTests
             Name = "test-app",
             Version = "1.0",
             Link = "github.com/test/repo",
-            Ports = [8080]
+            Port = 8080
         };
 
         var createdJob = new V1Job();

--- a/EvilGiraf.Tests/KubernetesTests.cs
+++ b/EvilGiraf.Tests/KubernetesTests.cs
@@ -12,14 +12,13 @@ namespace EvilGiraf.Tests;
 public class KubernetesTests
 {
     private readonly IDeploymentService _deploymentService;
-    private readonly IGitBuildService _gitBuildService;
     private readonly KubernetesService _kubernetesService;
 
     public KubernetesTests()
     {
         _deploymentService = Substitute.For<IDeploymentService>();
-        _gitBuildService = Substitute.For<IGitBuildService>();
-        _kubernetesService = new KubernetesService(_deploymentService, Substitute.For<INamespaceService>(), Substitute.For<IServiceService>(), _gitBuildService);
+        var gitBuildService = Substitute.For<IGitBuildService>();
+        _kubernetesService = new KubernetesService(_deploymentService, Substitute.For<INamespaceService>(), Substitute.For<IServiceService>(), gitBuildService);
     }
 
     private static Application CreateTestApplication() => new()
@@ -29,7 +28,7 @@ public class KubernetesTests
         Type = ApplicationType.Docker,
         Link = "docker.io/test:latest",
         Version = "1.0.0",
-        Ports = [22]
+        Port = 22
     };
 
     [Fact]

--- a/EvilGiraf.Tests/ServiceTests.cs
+++ b/EvilGiraf.Tests/ServiceTests.cs
@@ -13,8 +13,8 @@ namespace EvilGiraf.Tests;
 
 public class ServiceTests
 {
-    public IKubernetes Kubernetes { get; }
-    public IServiceService ServiceService { get; }
+    private IKubernetes Kubernetes { get; }
+    private IServiceService ServiceService { get; }
 
     public ServiceTests()
     {
@@ -50,10 +50,7 @@ public class ServiceTests
         var model = new ServiceModel(
             "service-test",
             "default",
-            "ClusterIP",
-            [80],
-            "TCP",
-            "app-test"
+            80
         );
         var result = await ServiceService.CreateService(model);
         result.Should().NotBeNull();
@@ -74,10 +71,7 @@ public class ServiceTests
         var model = new ServiceModel(
             "service-test",
             "default",
-            "ClusterIP",
-            [80],
-            "TCP",
-            "app-test"
+            80
         );
         var result = await ServiceService.CreateService(model);
         result.Should().NotBeNull();
@@ -164,10 +158,7 @@ public class ServiceTests
         var model = new ServiceModel(
             "service-test",
             "default",
-            "ClusterIP",
-            [80],
-            "TCP",
-            "app-test"
+            80
         );
         var result = await ServiceService.UpdateService(model);
         result.Should().NotBeNull();
@@ -181,10 +172,7 @@ public class ServiceTests
         var model = new ServiceModel(
             "service-test",
             "default",
-            "ClusterIP",
-            [80],
-            "TCP",
-            "app-test"
+            80
         );
         var httpException = new HttpOperationException
         {
@@ -202,10 +190,7 @@ public class ServiceTests
         var model = new ServiceModel(
             "service-test",
             "default",
-            "ClusterIP",
-            [80],
-            "TCP",
-            "app-test"
+            80
         );
         
         var existingService = new V1Service
@@ -236,10 +221,7 @@ public class ServiceTests
         var model = new ServiceModel(
             "service-test",
             "default",
-            "ClusterIP",
-            [80],
-            "TCP",
-            "app-test"
+            80
         );
         
         var httpException = new HttpOperationException

--- a/EvilGiraf/Dto/ApplicationDto.cs
+++ b/EvilGiraf/Dto/ApplicationDto.cs
@@ -7,7 +7,7 @@ public record ApplicationCreateDto(
     ApplicationType Type,
     string Link,
     string? Version,
-    int[]? Ports
+    int? Port
 );
 
 public record ApplicationResultDto(
@@ -16,7 +16,7 @@ public record ApplicationResultDto(
     ApplicationType Type,
     string Link,
     string? Version,
-    int[] Ports
+    int? Port
 );
 
 public record ApplicationUpdateDto(
@@ -24,5 +24,5 @@ public record ApplicationUpdateDto(
     ApplicationType? Type,
     string? Link,
     string? Version,
-    int[]? Ports
+    int? Port
 );

--- a/EvilGiraf/Extensions/ApplicationExtensions.cs
+++ b/EvilGiraf/Extensions/ApplicationExtensions.cs
@@ -13,7 +13,7 @@ public static class ApplicationExtensions
             application.Type,
             application.Link,
             application.Version,
-            application.Ports
+            application.Port
         );
     }
 
@@ -25,7 +25,7 @@ public static class ApplicationExtensions
             Type = applicationDto.Type,
             Link = applicationDto.Link,
             Version = applicationDto.Version,
-            Ports = applicationDto.Ports is not null ? applicationDto.Ports : Array.Empty<int>()
+            Port = applicationDto.Port
         };
     }
 }

--- a/EvilGiraf/Migrations/20250413135706_ApplicationSinglePort.Designer.cs
+++ b/EvilGiraf/Migrations/20250413135706_ApplicationSinglePort.Designer.cs
@@ -2,6 +2,7 @@
 using EvilGiraf.Service;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -10,9 +11,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace EvilGiraf.Migrations
 {
     [DbContext(typeof(DatabaseService))]
-    partial class DatabaseServiceModelSnapshot : ModelSnapshot
+    [Migration("20250413135706_ApplicationSinglePort")]
+    partial class ApplicationSinglePort
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/EvilGiraf/Migrations/20250413135706_ApplicationSinglePort.cs
+++ b/EvilGiraf/Migrations/20250413135706_ApplicationSinglePort.cs
@@ -1,0 +1,42 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EvilGiraf.Migrations
+{
+    /// <inheritdoc />
+    [ExcludeFromCodeCoverage]
+    public partial class ApplicationSinglePort : Migration
+    {
+        private const string TableName = "Applications";
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Ports",
+                table: TableName);
+
+            migrationBuilder.AddColumn<int>(
+                name: "Port",
+                table: TableName,
+                type: "integer",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Port",
+                table: TableName);
+
+            migrationBuilder.AddColumn<int[]>(
+                name: "Ports",
+                table: TableName,
+                type: "integer[]",
+                nullable: false,
+                defaultValue: Array.Empty<int>());
+        }
+    }
+}

--- a/EvilGiraf/Model/Application.cs
+++ b/EvilGiraf/Model/Application.cs
@@ -20,5 +20,5 @@ public class Application
     [MaxLength(255)]
     public string? Version { get; set; }
 
-    public required int[] Ports { get; set; }
+    public int? Port { get; set; }
 }

--- a/EvilGiraf/Model/DeploymentModel.cs
+++ b/EvilGiraf/Model/DeploymentModel.cs
@@ -2,7 +2,7 @@ using k8s.Models;
 
 namespace EvilGiraf.Model;
 
-public record DeploymentModel(string Name, string Namespace, int Replicas, string Image, int[] Ports);
+public record DeploymentModel(string Name, string Namespace, int Replicas, string Image, int? Port);
 
 public static class DeploymentModelExtensions
 {
@@ -43,7 +43,9 @@ public static class DeploymentModelExtensions
                             {
                                 Name = model.Name,
                                 Image = model.Image,
-                                Ports = model.Ports.Select(x => new V1ContainerPort(x)).ToList()
+                                Ports = model.Port is null ?
+                                    new List<V1ContainerPort>() :
+                                    new List<V1ContainerPort>{new(model.Port.Value)}
                             }
                         }
                     }

--- a/EvilGiraf/Model/ServiceModel.cs
+++ b/EvilGiraf/Model/ServiceModel.cs
@@ -2,7 +2,7 @@ using k8s.Models;
 
 namespace EvilGiraf.Model;
 
-public record ServiceModel(string Name, string Namespace, string Type, int[] Ports, string Protocol, string Selector);
+public record ServiceModel(string Name, string Namespace, int Port);
 
 public static class ServiceModelExtensions
 {   
@@ -17,16 +17,11 @@ public static class ServiceModelExtensions
             },
             Spec = new V1ServiceSpec
             {
-                Type = model.Type,
-                Ports = model.Ports.Select(p => new V1ServicePort
-                {
-                    Port = p,
-                    TargetPort = p,
-                    Protocol = model.Protocol
-                }).ToList(),
+                Type = "ClusterIP",
+                Ports = new List<V1ServicePort>{ new(model.Port)},
                 Selector = new Dictionary<string, string>
                 {
-                    { "app", model.Selector }
+                    { "app", model.Name }
                 }
             }
         };

--- a/EvilGiraf/Service/ApplicationService.cs
+++ b/EvilGiraf/Service/ApplicationService.cs
@@ -45,8 +45,8 @@ public class ApplicationService(DatabaseService databaseService) : IApplicationS
             application.Link = applicationUpdateDto.Link;
         if (applicationUpdateDto.Version is not null)
             application.Version = applicationUpdateDto.Version;
-        if (applicationUpdateDto.Ports is not null)
-            application.Ports = applicationUpdateDto.Ports;
+        if (applicationUpdateDto.Port is not null)
+            application.Port = applicationUpdateDto.Port;
 
         var updatedApp = databaseService.Applications.Update(application).Entity;
         await databaseService.SaveChangesAsync();

--- a/EvilGiraf/Service/KubernetesService.cs
+++ b/EvilGiraf/Service/KubernetesService.cs
@@ -28,23 +28,23 @@ public class KubernetesService(IDeploymentService deploymentService, INamespaceS
         if (deployment is null)
         {
             await deploymentService.CreateDeployment(new DeploymentModel(app.Name, app.Id.ToNamespace(), 1,
-                imageLink, app.Ports));
+                imageLink, app.Port));
 
-            if(app.Ports.Length > 0)
+            if(app.Port is not null)
             {
-                await serviceService.CreateService(new ServiceModel(app.Name, app.Id.ToNamespace(), "ClusterIP",
-                    app.Ports, "TCP", app.Name));
+                await serviceService.CreateService(new ServiceModel(app.Name, app.Id.ToNamespace(),
+                    app.Port.Value));
             }
         }
         else
         {
             await deploymentService.UpdateDeployment(new DeploymentModel(app.Name, app.Id.ToNamespace(), 1,
-                imageLink, app.Ports));
+                imageLink, app.Port));
 
-            if (app.Ports.Length > 0)
+            if (app.Port is not null)
             {
-                await serviceService.CreateIfNotExistsService(new ServiceModel(app.Name, app.Id.ToNamespace(), "ClusterIP",
-                    app.Ports, "TCP", app.Name));
+                await serviceService.CreateIfNotExistsService(new ServiceModel(app.Name, app.Id.ToNamespace(),
+                    app.Port.Value));
             }
         }
     }


### PR DESCRIPTION
This update modifies the `Application` model to use a single nullable `Port` instead of a collection of `Ports`. Related services, DTOs, and tests have been updated accordingly. Migration added to reflect this schema change.