### PR TITLE
feat: front update application port logic to support single nullable port

### DIFF
--- a/EvilGiraf.Front/src/pages/ApplicationDetails.tsx
+++ b/EvilGiraf.Front/src/pages/ApplicationDetails.tsx
@@ -101,7 +101,7 @@ export function ApplicationDetails() {
         type: application.type,
         link: application.link,
         version: application.version,
-        ports: application.ports,
+        port: application.port === null ? -1 : application.port,
       });
       setIsEditing(true);
     }
@@ -226,19 +226,16 @@ export function ApplicationDetails() {
                     />
                   </div>
                   <div>
-                    <span className="font-medium">Ports:</span>
+                    <span className="font-medium">Port:</span>
                     <input
-                      type="text"
-                      value={editedApp.ports?.join(', ') || ''}
+                      type="number"
+                      value={editedApp.port === -1 || editedApp.port === null || editedApp.port === undefined ? '' : editedApp.port.toString()}
                       onChange={(e) => {
-                        const ports = e.target.value
-                          .split(',')
-                          .map(port => parseInt(port.trim()))
-                          .filter(port => !isNaN(port));
-                        setEditedApp({ ...editedApp, ports });
+                        const port = e.target.value ? parseInt(e.target.value) : -1;
+                        setEditedApp({ ...editedApp, port });
                       }}
                       className="ml-2 p-1 border rounded"
-                      placeholder="e.g. 80, 443, 8080"
+                      placeholder="e.g. 80"
                     />
                   </div>
                 </>
@@ -258,10 +255,10 @@ export function ApplicationDetails() {
                     </p>
                   )}
                   <p>
-                    <span className="font-medium">Ports:</span>{' '}
-                    {application?.ports && application.ports.length > 0
-                      ? application.ports.join(', ')
-                      : 'No ports exposed'}
+                    <span className="font-medium">Port:</span>{' '}
+                    {application?.port !== null && application?.port !== undefined && application?.port !== -1
+                      ? application.port
+                      : 'No port exposed'}
                   </p>
                 </>
               )}

--- a/EvilGiraf.Front/src/pages/Applications.tsx
+++ b/EvilGiraf.Front/src/pages/Applications.tsx
@@ -13,7 +13,7 @@ export function Applications() {
     name: '',
     link: '',
     version: '',
-    ports: [],
+    port: null,
   });
 
   const { data: applications, isLoading, error } = useQuery(
@@ -27,7 +27,7 @@ export function Applications() {
       onSuccess: () => {
         queryClient.invalidateQueries('applications');
         setIsCreating(false);
-        setNewApp({ name: '', link: '', version: '', ports: [] });
+        setNewApp({ name: '', link: '', version: '', port: null });
       },
     }
   );
@@ -98,18 +98,15 @@ export function Applications() {
               />
             </div>
             <div>
-              <label className="block text-sm font-medium text-gray-700">Ports (comma-separated)</label>
+              <label className="block text-sm font-medium text-gray-700">Port</label>
               <input
-                type="text"
-                value={newApp.ports?.join(', ') || ''}
+                type="number"
+                value={newApp.port || ''}
                 onChange={(e) => {
-                  const ports = e.target.value
-                    .split(',')
-                    .map(port => parseInt(port.trim()))
-                    .filter(port => !isNaN(port));
-                  setNewApp({ ...newApp, ports });
+                  const port = e.target.value ? parseInt(e.target.value) : null;
+                  setNewApp({ ...newApp, port });
                 }}
-                placeholder="e.g. 80, 443, 8080"
+                placeholder="e.g. 80"
                 className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
               />
             </div>

--- a/EvilGiraf.Front/src/pages/Applications.tsx
+++ b/EvilGiraf.Front/src/pages/Applications.tsx
@@ -101,7 +101,7 @@ export function Applications() {
               <label className="block text-sm font-medium text-gray-700">Port</label>
               <input
                 type="number"
-                value={newApp.port || ''}
+                value={(newApp.port !== null && newApp.port !== undefined) ? newApp.port : ''}
                 onChange={(e) => {
                   const port = e.target.value ? parseInt(e.target.value) : null;
                   setNewApp({ ...newApp, port });

--- a/EvilGiraf.Front/src/types/api.ts
+++ b/EvilGiraf.Front/src/types/api.ts
@@ -3,7 +3,7 @@ export interface ApplicationCreateDto {
   type?: ApplicationType;
   link?: string;
   version?: string;
-  ports?: number[];
+  port?: number | null;
 }
 
 export interface ApplicationResultDto {
@@ -12,7 +12,7 @@ export interface ApplicationResultDto {
   type: ApplicationType;
   link?: string;
   version?: string;
-  ports?: number[];
+  port?: number | null;
 }
 
 export enum ApplicationType {

--- a/EvilGiraf.Tests/ApplicationTests.cs
+++ b/EvilGiraf.Tests/ApplicationTests.cs
@@ -116,6 +116,30 @@ public class ApplicationTests
     }
     
     [Fact]
+    public async Task UpdateApplication_NegativePort_ShouldSetNull()
+    {
+        // Arrange
+        var applicationDto = new ApplicationCreateDto(
+            "TestApp", ApplicationType.Docker, "https://test.com", "1.0.0", 22);
+        var createdApplication = await _applicationService.CreateApplication(applicationDto);
+
+        var updatedApplicationDto = new ApplicationUpdateDto(
+            null, null, null, null, -1);
+
+        // Act
+        var result = await _applicationService.UpdateApplication(createdApplication.Id, updatedApplicationDto);
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.Id.Should().Be(createdApplication.Id);
+        result.Name.Should().Be(applicationDto.Name);
+        result.Type.Should().Be(applicationDto.Type);
+        result.Link.Should().Be(applicationDto.Link);
+        result.Version.Should().Be(applicationDto.Version);
+        result.Port.Should().BeNull();
+    }
+    
+    [Fact]
     public async Task UpdateApplication_ShouldReturnNotUpdatedApplication()
     {
         // Arrange

--- a/EvilGiraf/Service/ApplicationService.cs
+++ b/EvilGiraf/Service/ApplicationService.cs
@@ -46,7 +46,10 @@ public class ApplicationService(DatabaseService databaseService) : IApplicationS
         if (applicationUpdateDto.Version is not null)
             application.Version = applicationUpdateDto.Version;
         if (applicationUpdateDto.Port is not null)
-            application.Port = applicationUpdateDto.Port;
+            application.Port = 
+                applicationUpdateDto.Port < 0 ?
+                    null :
+                    applicationUpdateDto.Port;
 
         var updatedApp = databaseService.Applications.Update(application).Entity;
         await databaseService.SaveChangesAsync();


### PR DESCRIPTION
Replaced multi-port support with a single nullable port across the application. Updated backend validation to set port to null if a negative value is provided and adjusted frontend to handle the change in port data structure. Updated tests to reflect the new behavior.