### PR TITLE
refactor: update ApplicationCreateDto and ApplicationUpdateDto in tes…

### DIFF
--- a/EvilGiraf.IntegrationTests/ApplicationControllerTests.cs
+++ b/EvilGiraf.IntegrationTests/ApplicationControllerTests.cs
@@ -64,11 +64,11 @@ public class ApplicationControllerTests : AuthenticatedTestBase
     public async Task CreateWithNameContainingSpaces_ShouldReturnBadRequest()
     {
         
-        var invalidNames = new[] { null, "", "invalid name" };
+        var invalidNames = new[] { "", "invalid name" };
         foreach (var name in invalidNames)
         {   
             // Arrange
-            var createRequest = new ApplicationCreateDto(name, ApplicationType.Docker, "docker.io/test-application:latest", "1.0.0", [22]);
+            var createRequest = new ApplicationCreateDto(name, ApplicationType.Docker, "docker.io/test-application:latest", "1.0.0", 22);
 
             // Act
             var response = await Client.PostAsJsonAsync("/api/application", createRequest);
@@ -179,7 +179,7 @@ public class ApplicationControllerTests : AuthenticatedTestBase
             Type = ApplicationType.Docker,
             Link = "docker.io/valid-name:latest",
             Version = "1.0.0",
-            Ports = [22]
+            Port = 22
         };
 
         _dbContext.Applications.Add(application);
@@ -188,7 +188,7 @@ public class ApplicationControllerTests : AuthenticatedTestBase
         var invalidNames = new[] { "", "invalid name" }; //null value wasn't added because it's DTO work
         foreach (var name in invalidNames)
         {
-            var updateRequest = new ApplicationUpdateDto(name, ApplicationType.Git, "k8s.io/invalid-name:latest", "2.0.0", [23]);
+            var updateRequest = new ApplicationUpdateDto(name, ApplicationType.Git, "k8s.io/invalid-name:latest", "2.0.0", 23);
 
             // Act
             var response = await Client.PatchAsJsonAsync($"/api/application/{application.Id}", updateRequest);

--- a/EvilGiraf.IntegrationTests/ApplicationControllerTests.cs
+++ b/EvilGiraf.IntegrationTests/ApplicationControllerTests.cs
@@ -60,22 +60,20 @@ public class ApplicationControllerTests : AuthenticatedTestBase
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
     
-    [Fact]
-    public async Task CreateWithNameContainingSpaces_ShouldReturnBadRequest()
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("invalid name")]
+    public async Task CreateWithNameContainingSpaces_ShouldReturnBadRequest(string? name)
     {
-        
-        var invalidNames = new[] { "", "invalid name" };
-        foreach (var name in invalidNames)
-        {   
-            // Arrange
-            var createRequest = new ApplicationCreateDto(name, ApplicationType.Docker, "docker.io/test-application:latest", "1.0.0", 22);
+        // Arrange
+        var createRequest = new ApplicationCreateDto(name!, ApplicationType.Docker, "docker.io/test-application:latest", "1.0.0", 22);
 
-            // Act
-            var response = await Client.PostAsJsonAsync("/api/application", createRequest);
+        // Act
+        var response = await Client.PostAsJsonAsync("/api/application", createRequest);
 
-            // Assert
-            response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-        }
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
 
     [Fact]


### PR DESCRIPTION
This pull request includes changes to the `EvilGiraf.IntegrationTests/ApplicationControllerTests.cs` file to fix issues with the handling of port numbers and invalid names in test cases. The most important changes are:

Test case improvements:

* [`public async Task CreateWithWrongBody_ShouldReturnBadRequest()`](diffhunk://#diff-d41f11456c621976336f13cf3d5fd3b37b8b6fa73ae592bb6cb9e2c180b36a1bL67-R71): Removed `null` from the `invalidNames` array and corrected the `Ports` parameter from an array to a single integer value in the `ApplicationCreateDto` instantiation.
* [`public async Task UpdateNameAppWithSpaces_ShouldReturnBadRequest()`](diffhunk://#diff-d41f11456c621976336f13cf3d5fd3b37b8b6fa73ae592bb6cb9e2c180b36a1bL191-R191): Corrected the `Ports` parameter from an array to a single integer value in the `ApplicationUpdateDto` instantiation.

Code consistency:

* [`public async Task UpdateNameAppWithSpaces_ShouldReturnBadRequest()`](diffhunk://#diff-d41f11456c621976336f13cf3d5fd3b37b8b6fa73ae592bb6cb9e2c180b36a1bL182-R182): Changed the `Ports` property to `Port` in the application object setup.