### PR TITLE
feat: add ConfigMap handling to Kubernetes service

### DIFF
--- a/EvilGiraf.Front/src/pages/ApplicationDetails.tsx
+++ b/EvilGiraf.Front/src/pages/ApplicationDetails.tsx
@@ -12,6 +12,7 @@ export function ApplicationDetails() {
   const queryClient = useQueryClient();
   const [isEditing, setIsEditing] = useState(false);
   const [editedApp, setEditedApp] = useState<ApplicationCreateDto>({});
+  const [newVariable, setNewVariable] = useState('');
 
   const {
     data: application,
@@ -84,6 +85,7 @@ export function ApplicationDetails() {
         queryClient.invalidateQueries(['application', id]);
         setIsEditing(false);
         setEditedApp({});
+        setNewVariable('');
       },
     }
   );
@@ -103,6 +105,7 @@ export function ApplicationDetails() {
         version: application.version,
         port: application.port === null ? -1 : application.port,
         domainName: application.domainName,
+        variables: application.variables || [],
       });
       setIsEditing(true);
     }
@@ -115,6 +118,26 @@ export function ApplicationDetails() {
   const handleCancel = () => {
     setIsEditing(false);
     setEditedApp({});
+    setNewVariable('');
+  };
+
+  const handleAddVariable = () => {
+    if (newVariable.trim() && newVariable.includes('=')) {
+      setEditedApp({
+        ...editedApp,
+        variables: [...(editedApp.variables || []), newVariable.trim()]
+      });
+      setNewVariable('');
+    }
+  };
+
+  const handleRemoveVariable = (index: number) => {
+    const updatedVariables = [...(editedApp.variables || [])];
+    updatedVariables.splice(index, 1);
+    setEditedApp({
+      ...editedApp,
+      variables: updatedVariables
+    });
   };
 
   if (isLoadingApp) return <LoadingSpinner />;
@@ -258,8 +281,44 @@ export function ApplicationDetails() {
                         : '(Enter domain without http:// or https:// that points to the server)'}
                     </span>
                   </div>
+                  <div>
+                    <span className="font-medium">Environment Variables:</span>
+                    <div className="mt-1 flex">
+                      <input
+                        type="text"
+                        value={newVariable}
+                        onChange={(e) => setNewVariable(e.target.value)}
+                        placeholder="KEY=VALUE"
+                        className="ml-2 p-1 border rounded-l w-full"
+                      />
+                      <button
+                        onClick={handleAddVariable}
+                        className="bg-blue-500 text-white px-3 py-1 rounded-r hover:bg-blue-600"
+                      >
+                        Add
+                      </button>
+                    </div>
+                    <p className="text-sm text-gray-500 ml-2 mt-1">
+                      Format: KEY=VALUE (e.g., DATABASE_URL=postgres://user:pass@host:5432/db)
+                    </p>
+                    {editedApp.variables && editedApp.variables.length > 0 && (
+                      <div className="mt-2 space-y-1 ml-2">
+                        {editedApp.variables.map((variable, index) => (
+                          <div key={index} className="flex items-center justify-between bg-gray-50 p-2 rounded">
+                            <span className="text-sm font-mono">{variable}</span>
+                            <button
+                              onClick={() => handleRemoveVariable(index)}
+                              className="text-red-500 hover:text-red-700"
+                            >
+                              <Trash2 className="h-4 w-4" />
+                            </button>
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                  </div>
                 </>
-              ) : (
+              ) :
                 <>
                   <p>
                     <span className="font-medium">Type:</span>{' '}
@@ -302,8 +361,20 @@ export function ApplicationDetails() {
                       </span>
                     )}
                   </p>
+                  {application?.variables && application.variables.length > 0 && (
+                    <div>
+                      <span className="font-medium">Environment Variables:</span>
+                      <div className="mt-2 space-y-1">
+                        {application.variables.map((variable, index) => (
+                          <div key={index} className="bg-gray-50 p-2 rounded">
+                            <span className="text-sm font-mono">{variable}</span>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  )}
                 </>
-              )}
+              }
             </div>
           </div>
 

--- a/EvilGiraf.Front/src/pages/ApplicationDetails.tsx
+++ b/EvilGiraf.Front/src/pages/ApplicationDetails.tsx
@@ -1,6 +1,6 @@
 import { useParams, useNavigate } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from 'react-query';
-import { ArrowLeft, RefreshCw, Trash2, Edit2, Save, X, Power } from 'lucide-react';
+import { ArrowLeft, RefreshCw, Trash2, Edit2, Power } from 'lucide-react';
 import { api } from '../lib/api';
 import { LoadingSpinner } from '../components/LoadingSpinner';
 import { ApplicationCreateDto, ApplicationType } from '../types/api';
@@ -173,23 +173,12 @@ export function ApplicationDetails() {
               </button>
             </>
           ) : (
-            <>
-              <button
-                onClick={handleCancel}
-                className="flex items-center gap-2 text-gray-500 hover:text-gray-700"
-              >
-                <X className="h-5 w-5" />
-                Cancel
-              </button>
-              <button
-                onClick={handleSave}
-                disabled={updateMutation.isLoading}
-                className="flex items-center gap-2 text-green-500 hover:text-green-700 disabled:opacity-50"
-              >
-                <Save className="h-5 w-5" />
-                {updateMutation.isLoading ? 'Saving...' : 'Save'}
-              </button>
-            </>
+            <button
+              onClick={handleCancel}
+              className="bg-gray-100 text-gray-700 px-4 py-2 rounded-lg flex items-center gap-2 hover:bg-gray-200 border border-gray-300"
+            >
+              Cancel
+            </button>
           )}
         </div>
       </div>
@@ -441,6 +430,17 @@ export function ApplicationDetails() {
             )}
           </div>
         </div>
+        {isEditing && (
+          <div className="flex justify-end gap-2 mt-6">
+            <button
+              onClick={handleSave}
+              disabled={updateMutation.isLoading}
+              className="px-4 py-2 bg-blue-500 text-white rounded-md hover:bg-blue-600 disabled:opacity-50"
+            >
+              {updateMutation.isLoading ? 'Saving...' : 'Save'}
+            </button>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/EvilGiraf.Front/src/pages/Applications.tsx
+++ b/EvilGiraf.Front/src/pages/Applications.tsx
@@ -69,13 +69,22 @@ export function Applications() {
     <div>
       <div className="flex justify-between items-center mb-6">
         <h1 className="text-2xl font-bold">Applications</h1>
-        <button
-          onClick={() => setIsCreating(true)}
-          className="bg-blue-500 text-white px-4 py-2 rounded-lg flex items-center gap-2 hover:bg-blue-600"
-        >
-          <Plus className="h-5 w-5" />
-          New Application
-        </button>
+        {!isCreating ? (
+          <button
+            onClick={() => setIsCreating(true)}
+            className="bg-blue-500 text-white px-4 py-2 rounded-lg flex items-center gap-2 hover:bg-blue-600"
+          >
+            <Plus className="h-5 w-5" />
+            New Application
+          </button>
+        ) : (
+          <button
+            onClick={() => setIsCreating(false)}
+            className="bg-gray-100 text-gray-700 px-4 py-2 rounded-lg flex items-center gap-2 hover:bg-gray-200 border border-gray-300"
+          >
+            Cancel
+          </button>
+        )}
       </div>
 
       {isCreating && (
@@ -191,12 +200,6 @@ export function Applications() {
               )}
             </div>
             <div className="flex justify-end gap-2">
-              <button
-                onClick={() => setIsCreating(false)}
-                className="px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-50"
-              >
-                Cancel
-              </button>
               <button
                 onClick={() => createMutation.mutate(newApp)}
                 className="px-4 py-2 bg-blue-500 text-white rounded-md hover:bg-blue-600"

--- a/EvilGiraf.Front/src/pages/Applications.tsx
+++ b/EvilGiraf.Front/src/pages/Applications.tsx
@@ -15,7 +15,9 @@ export function Applications() {
     version: '',
     port: null,
     domainName: null,
+    variables: [],
   });
+  const [newVariable, setNewVariable] = useState('');
 
   const { data: applications, isLoading, error } = useQuery(
     'applications',
@@ -28,7 +30,8 @@ export function Applications() {
       onSuccess: () => {
         queryClient.invalidateQueries('applications');
         setIsCreating(false);
-        setNewApp({ name: '', link: '', version: '', port: null, domainName: null });
+        setNewApp({ name: '', link: '', version: '', port: null, domainName: null, variables: [] });
+        setNewVariable('');
       },
     }
   );
@@ -39,6 +42,25 @@ export function Applications() {
       onSuccess: () => queryClient.invalidateQueries('applications'),
     }
   );
+
+  const handleAddVariable = () => {
+    if (newVariable.trim() && newVariable.includes('=')) {
+      setNewApp({
+        ...newApp,
+        variables: [...(newApp.variables || []), newVariable.trim()]
+      });
+      setNewVariable('');
+    }
+  };
+
+  const handleRemoveVariable = (index: number) => {
+    const updatedVariables = [...(newApp.variables || [])];
+    updatedVariables.splice(index, 1);
+    setNewApp({
+      ...newApp,
+      variables: updatedVariables
+    });
+  };
 
   if (isLoading) return <LoadingSpinner />;
   if (error) return <div className="text-red-500">Error: {(error as Error).message}</div>;
@@ -132,6 +154,42 @@ export function Applications() {
                   : '(Enter domain without http:// or https:// that points to the server)'}
               </p>
             </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700">Environment Variables</label>
+              <div className="mt-1 flex">
+                <input
+                  type="text"
+                  value={newVariable}
+                  onChange={(e) => setNewVariable(e.target.value)}
+                  placeholder="KEY=VALUE"
+                  className="block w-full rounded-l-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+                />
+                <button
+                  onClick={handleAddVariable}
+                  className="bg-blue-500 text-white px-3 py-2 rounded-r-md hover:bg-blue-600"
+                >
+                  Add
+                </button>
+              </div>
+              <p className="mt-1 text-sm text-gray-500">
+                Format: KEY=VALUE (e.g., DATABASE_URL=postgres://user:pass@host:5432/db)
+              </p>
+              {newApp.variables && newApp.variables.length > 0 && (
+                <div className="mt-2 space-y-1">
+                  {newApp.variables.map((variable, index) => (
+                    <div key={index} className="flex items-center justify-between bg-gray-50 p-2 rounded">
+                      <span className="text-sm font-mono">{variable}</span>
+                      <button
+                        onClick={() => handleRemoveVariable(index)}
+                        className="text-red-500 hover:text-red-700"
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
             <div className="flex justify-end gap-2">
               <button
                 onClick={() => setIsCreating(false)}
@@ -168,6 +226,9 @@ export function Applications() {
               <p className="text-gray-600">Version: {app.version || 'N/A'}</p>
               {app.link && (
                 <p className="text-gray-600">Link: {app.link}</p>
+              )}
+              {app.variables && app.variables.length > 0 && (
+                <p className="text-gray-600">Environment Variables: {app.variables.length}</p>
               )}
             </div>
             <Link

--- a/EvilGiraf.Front/src/types/api.ts
+++ b/EvilGiraf.Front/src/types/api.ts
@@ -5,6 +5,7 @@ export interface ApplicationCreateDto {
   version?: string;
   port?: number | null;
   domainName?: string | null;
+  variables?: string[] | null;
 }
 
 export interface ApplicationResultDto {
@@ -15,6 +16,7 @@ export interface ApplicationResultDto {
   version?: string;
   port?: number | null;
   domainName?: string | null;
+  variables?: string[] | null;
 }
 
 export enum ApplicationType {

--- a/EvilGiraf.IntegrationTests/ApplicationControllerTests.cs
+++ b/EvilGiraf.IntegrationTests/ApplicationControllerTests.cs
@@ -309,7 +309,8 @@ public class ApplicationControllerTests : AuthenticatedTestBase
                 Type = ApplicationType.Docker,
                 Link = "docker.io/test-application-1:latest",
                 Version = "1.0.0",
-                Port = 22
+                Port = 22,
+                Variables = []
             },
             new()
             {
@@ -317,7 +318,8 @@ public class ApplicationControllerTests : AuthenticatedTestBase
                 Type = ApplicationType.Git,
                 Link = "k8s.io/test-application-2:latest",
                 Version = "2.0.0",
-                Port = 22
+                Port = 22,
+                Variables = ["KEY=VALUE", "KEY2=VALUE2"]
             }
         };
 

--- a/EvilGiraf.IntegrationTests/ApplicationControllerTests.cs
+++ b/EvilGiraf.IntegrationTests/ApplicationControllerTests.cs
@@ -20,7 +20,7 @@ public class ApplicationControllerTests : AuthenticatedTestBase
     public async Task Create_ShouldCreateApplication()
     {
         // Arrange
-        var createRequest = new ApplicationCreateDto("test-application", ApplicationType.Docker, "docker.io/test-application:latest", "1.0.0", 22, null);
+        var createRequest = new ApplicationCreateDto("test-application", ApplicationType.Docker, "docker.io/test-application:latest", "1.0.0", 22, "test.com", ["KEY=VAR", "KEY2=VAR2"]);
 
         // Act
         var response = await Client.PostAsJsonAsync("/api/application", createRequest);
@@ -36,6 +36,8 @@ public class ApplicationControllerTests : AuthenticatedTestBase
         application.Version.Should().Be(createRequest.Version);
         application.Id.Should().NotBe(0);
         application.Port.Should().Be(createRequest.Port);
+        application.DomainName.Should().Be(createRequest.DomainName);
+        application.Variables.Should().BeEquivalentTo(createRequest.Variables);
 
         // Verify the application was saved to the database
         var savedApplication = await _dbContext.Applications.FindAsync(application.Id);
@@ -45,19 +47,8 @@ public class ApplicationControllerTests : AuthenticatedTestBase
         savedApplication.Link.Should().Be(createRequest.Link);
         savedApplication.Version.Should().Be(createRequest.Version);
         savedApplication.Port.Should().Be(createRequest.Port);
-    }
-
-    [Fact]
-    public async Task CreateWithWrongBody_ShouldReturnBadRequest()
-    {
-        // Arrange
-        var createRequest = new ApplicationCreateDto(null!, ApplicationType.Docker, "docker.io/test-application:latest", "1.0.0", 22, null);
-
-        // Act
-        var response = await Client.PostAsJsonAsync("/api/application", createRequest);
-
-        // Assert
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        savedApplication.DomainName.Should().Be(createRequest.DomainName);
+        savedApplication.Variables.Should().BeEquivalentTo(createRequest.Variables);
     }
     
     [Theory]
@@ -67,7 +58,7 @@ public class ApplicationControllerTests : AuthenticatedTestBase
     public async Task CreateWithNameContainingSpaces_ShouldReturnBadRequest(string? name)
     {
         // Arrange
-        var createRequest = new ApplicationCreateDto(name!, ApplicationType.Docker, "docker.io/test-application:latest", "1.0.0", 22, null);
+        var createRequest = new ApplicationCreateDto(name!, ApplicationType.Docker, "docker.io/test-application:latest", "1.0.0", 22, null, null);
 
         // Act
         var response = await Client.PostAsJsonAsync("/api/application", createRequest);
@@ -186,7 +177,7 @@ public class ApplicationControllerTests : AuthenticatedTestBase
         var invalidNames = new[] { "", "invalid name" }; //null value wasn't added because it's DTO work
         foreach (var name in invalidNames)
         {
-            var updateRequest = new ApplicationUpdateDto(name, ApplicationType.Git, "k8s.io/invalid-name:latest", "2.0.0", 23, null);
+            var updateRequest = new ApplicationUpdateDto(name, ApplicationType.Git, "k8s.io/invalid-name:latest", "2.0.0", 23, null, null);
 
             // Act
             var response = await Client.PatchAsJsonAsync($"/api/application/{application.Id}", updateRequest);
@@ -207,13 +198,14 @@ public class ApplicationControllerTests : AuthenticatedTestBase
             Link = "docker.io/test-application:latest",
             Version = "1.0.0",
             Port = 22,
-            DomainName = "test-application.com"
+            DomainName = "test-application.com",
+            Variables = ["KEY=VALUE", "KEY2=VALUE2"]
         };
 
         _dbContext.Applications.Add(application);
         await _dbContext.SaveChangesAsync();
 
-        var updateRequest = new ApplicationUpdateDto("updated-application", ApplicationType.Git, "k8s.io/updated-application:latest", "2.0.0", 23, "updated-application.com");
+        var updateRequest = new ApplicationUpdateDto("updated-application", ApplicationType.Git, "k8s.io/updated-application:latest", "2.0.0", 23, "updated-application.com", ["KEY=UPDATED", "KEY2=UPDATED2"]);
 
         // Act
         var response = await Client.PatchAsJsonAsync($"/api/application/{application.Id}", updateRequest);
@@ -250,7 +242,7 @@ public class ApplicationControllerTests : AuthenticatedTestBase
     public async Task UpdateWithNonExistingId_ShouldReturnNotFound()
     {
         // Arrange
-        var updateRequest = new ApplicationUpdateDto("updated-application", ApplicationType.Git, "k8s.io/updated-application:latest", "2.0.0", 22, null);
+        var updateRequest = new ApplicationUpdateDto("updated-application", ApplicationType.Git, "k8s.io/updated-application:latest", "2.0.0", 22, null, null);
 
         // Act
         var response = await Client.PatchAsJsonAsync($"/api/application/{999}", updateRequest);
@@ -275,7 +267,7 @@ public class ApplicationControllerTests : AuthenticatedTestBase
         _dbContext.Applications.Add(application);
         await _dbContext.SaveChangesAsync();
 
-        var updateRequest = new ApplicationUpdateDto(null, null, null, null, null, null);
+        var updateRequest = new ApplicationUpdateDto(null, null, null, null, null, null, null);
 
         // Act
         var response = await Client.PatchAsJsonAsync($"/api/application/{application.Id}", updateRequest);
@@ -350,7 +342,7 @@ public class ApplicationControllerTests : AuthenticatedTestBase
     public async Task CreateWithNoPort_ShouldReturnApplication()
     {
         // Arrange
-        var createRequest = new ApplicationCreateDto("test-application", ApplicationType.Docker, "docker.io/test-application:latest", "1.0.0", null, null);
+        var createRequest = new ApplicationCreateDto("test-application", ApplicationType.Docker, "docker.io/test-application:latest", "1.0.0", null, null, null);
 
         // Act
         var response = await Client.PostAsJsonAsync("/api/application", createRequest);

--- a/EvilGiraf.Tests/ApplicationTests.cs
+++ b/EvilGiraf.Tests/ApplicationTests.cs
@@ -20,7 +20,7 @@ public class ApplicationTests
     public async Task CreateApplication_ShouldCreateAndReturnNewApplication()
     {
         // Arrange
-        var application = new ApplicationCreateDto("TestApp", ApplicationType.Docker, "https://test.com", "1.0.0", 22, null);
+        var application = new ApplicationCreateDto("TestApp", ApplicationType.Docker, "https://test.com", "1.0.0", 22, null, null);
 
         // Act
         var result = await _applicationService.CreateApplication(application);
@@ -38,7 +38,7 @@ public class ApplicationTests
     public async Task GetApplication_ShouldReturnApplication()
     {
         // Arrange
-        var application = new ApplicationCreateDto("TestApp", ApplicationType.Docker, "https://test.com", "1.0.0", 22, null);
+        var application = new ApplicationCreateDto("TestApp", ApplicationType.Docker, "https://test.com", "1.0.0", 22, null, null);
         var createdApplication = await _applicationService.CreateApplication(application);
 
         // Act
@@ -68,7 +68,7 @@ public class ApplicationTests
     public async Task DeleteApplication_ShouldDeleteApplication()
     {
         // Arrange
-        var application = new ApplicationCreateDto("TestApp", ApplicationType.Docker, "https://test.com", "1.0.0", 22, null);
+        var application = new ApplicationCreateDto("TestApp", ApplicationType.Docker, "https://test.com", "1.0.0", 22, null, null);
         var createdApplication = await _applicationService.CreateApplication(application);
 
         // Act
@@ -96,11 +96,11 @@ public class ApplicationTests
     {
         // Arrange
         var applicationDto = new ApplicationCreateDto(
-            "TestApp", ApplicationType.Docker, "https://test.com", "1.0.0", 22, null);
+            "TestApp", ApplicationType.Docker, "https://test.com", "1.0.0", 22, null, null);
         var createdApplication = await _applicationService.CreateApplication(applicationDto);
 
         var updatedApplicationDto = new ApplicationUpdateDto(
-            "UpdatedTestApp", ApplicationType.Docker, "https://updatedtest.com", "2.0.0", 23, null);
+            "UpdatedTestApp", ApplicationType.Docker, "https://updatedtest.com", "2.0.0", 23, null, null);
 
         // Act
         var result = await _applicationService.UpdateApplication(createdApplication.Id, updatedApplicationDto);
@@ -120,11 +120,11 @@ public class ApplicationTests
     {
         // Arrange
         var applicationDto = new ApplicationCreateDto(
-            "TestApp", ApplicationType.Docker, "https://test.com", "1.0.0", 22, null);
+            "TestApp", ApplicationType.Docker, "https://test.com", "1.0.0", 22, null, null);
         var createdApplication = await _applicationService.CreateApplication(applicationDto);
 
         var updatedApplicationDto = new ApplicationUpdateDto(
-            null, null, null, null, -1, null);
+            null, null, null, null, -1, null, null);
 
         // Act
         var result = await _applicationService.UpdateApplication(createdApplication.Id, updatedApplicationDto);
@@ -144,11 +144,11 @@ public class ApplicationTests
     {
         // Arrange
         var applicationDto = new ApplicationCreateDto(
-            "TestApp", ApplicationType.Docker, "https://test.com", "1.0.0", 22, null);
+            "TestApp", ApplicationType.Docker, "https://test.com", "1.0.0", 22, null, null);
         var createdApplication = await _applicationService.CreateApplication(applicationDto);
 
         var updatedApplicationDto = new ApplicationUpdateDto(
-            null, null, null, null, null, null);
+            null, null, null, null, null, null, null);
 
         // Act
         var result = await _applicationService.UpdateApplication(createdApplication.Id, updatedApplicationDto);
@@ -168,7 +168,7 @@ public class ApplicationTests
     {
         // Arrange
         var updatedApplicationDto = new ApplicationUpdateDto(
-            "UpdatedTestApp", ApplicationType.Docker, "https://updatedtest.com", "2.0.0", 22, null);
+            "UpdatedTestApp", ApplicationType.Docker, "https://updatedtest.com", "2.0.0", 22, null, null);
 
         // Act
         var result = await _applicationService.UpdateApplication(999, updatedApplicationDto);
@@ -187,9 +187,9 @@ public class ApplicationTests
             await _applicationService.DeleteApplication(app.Id);
         }
 
-        var application1 = new ApplicationCreateDto("TestApp1", ApplicationType.Docker, "https://test.com", "1.0.0", 22, null);
-        var application2 = new ApplicationCreateDto("TestApp2", ApplicationType.Docker, "https://test.com", "1.0.0", 22, null);
-        var application3 = new ApplicationCreateDto("TestApp3", ApplicationType.Docker, "https://test.com", "1.0.0", 22, null);
+        var application1 = new ApplicationCreateDto("TestApp1", ApplicationType.Docker, "https://test.com", "1.0.0", 22, null, null);
+        var application2 = new ApplicationCreateDto("TestApp2", ApplicationType.Docker, "https://test.com", "1.0.0", 22, null, null);
+        var application3 = new ApplicationCreateDto("TestApp3", ApplicationType.Docker, "https://test.com", "1.0.0", 22, null, null);
 
         await _applicationService.CreateApplication(application1);
         await _applicationService.CreateApplication(application2);

--- a/EvilGiraf.Tests/DeploymentTests.cs
+++ b/EvilGiraf.Tests/DeploymentTests.cs
@@ -1,6 +1,6 @@
 using System.Net;
 using EvilGiraf.Interface.Kubernetes;
-using EvilGiraf.Model;
+using EvilGiraf.Model.Kubernetes;
 using EvilGiraf.Service.Kubernetes;
 using FluentAssertions;
 using k8s;
@@ -54,7 +54,8 @@ public class DeploymentTests
             "default",
             1,
             "nginx",
-            80
+            80,
+            "configmap-test"
         );
         var result = await DeploymentService.CreateDeployment(model);
         result.Should().NotBeNull();
@@ -77,7 +78,8 @@ public class DeploymentTests
             "default",
             1,
             "nginx",
-            80
+            80,
+            null
         );
         var result = await DeploymentService.CreateDeployment(model);
         result.Should().NotBeNull();
@@ -166,7 +168,8 @@ public class DeploymentTests
             "default",
             1,
             "nginx",
-            80
+            80,
+            null
         );
         var result = await DeploymentService.UpdateDeployment(model);
         result.Should().NotBeNull();
@@ -182,7 +185,8 @@ public class DeploymentTests
             "default",
             1,
             "nginx",
-            80
+            80,
+            null
         );
         var httpException = new HttpOperationException
         {

--- a/EvilGiraf.Tests/GitBuildTests.cs
+++ b/EvilGiraf.Tests/GitBuildTests.cs
@@ -1,4 +1,5 @@
 using EvilGiraf.Model;
+using EvilGiraf.Model.Kubernetes;
 using EvilGiraf.Service;
 using FluentAssertions;
 using k8s;

--- a/EvilGiraf.Tests/KubernetesTests.cs
+++ b/EvilGiraf.Tests/KubernetesTests.cs
@@ -1,6 +1,7 @@
 using EvilGiraf.Interface.Kubernetes;
 using EvilGiraf.Interface;
 using EvilGiraf.Model;
+using EvilGiraf.Model.Kubernetes;
 using EvilGiraf.Service;
 using FluentAssertions;
 using k8s.Models;
@@ -18,7 +19,7 @@ public class KubernetesTests
     {
         _deploymentService = Substitute.For<IDeploymentService>();
         var gitBuildService = Substitute.For<IGitBuildService>();
-        _kubernetesService = new KubernetesService(_deploymentService, Substitute.For<INamespaceService>(), Substitute.For<IServiceService>(), gitBuildService, Substitute.For<IIngressService>());
+        _kubernetesService = new KubernetesService(_deploymentService, Substitute.For<INamespaceService>(), Substitute.For<IServiceService>(), gitBuildService, Substitute.For<IIngressService>(), Substitute.For<IConfigMapService>());
     }
 
     private static Application CreateTestApplication() => new()

--- a/EvilGiraf.Tests/ServiceTests.cs
+++ b/EvilGiraf.Tests/ServiceTests.cs
@@ -1,6 +1,6 @@
 using System.Net;
-using EvilGiraf.Interface;
-using EvilGiraf.Model;
+using EvilGiraf.Interface.Kubernetes;
+using EvilGiraf.Model.Kubernetes;
 using EvilGiraf.Service.Kubernetes;
 using FluentAssertions;
 using k8s.Models;

--- a/EvilGiraf/Controller/DeploymentController.cs
+++ b/EvilGiraf/Controller/DeploymentController.cs
@@ -1,7 +1,7 @@
 using EvilGiraf.Dto;
 using EvilGiraf.Interface;
 using EvilGiraf.Interface.Kubernetes;
-using EvilGiraf.Model;
+using EvilGiraf.Model.Kubernetes;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 

--- a/EvilGiraf/Dto/ApplicationDto.cs
+++ b/EvilGiraf/Dto/ApplicationDto.cs
@@ -8,7 +8,8 @@ public record ApplicationCreateDto(
     string Link,
     string? Version,
     int? Port,
-    string? DomainName
+    string? DomainName,
+    string[]? Variables
 );
 
 public record ApplicationResultDto(
@@ -18,7 +19,8 @@ public record ApplicationResultDto(
     string Link,
     string? Version,
     int? Port,
-    string? DomainName
+    string? DomainName,
+    string[] Variables
 );
 
 public record ApplicationUpdateDto(
@@ -27,5 +29,6 @@ public record ApplicationUpdateDto(
     string? Link,
     string? Version,
     int? Port,
-    string? DomainName
+    string? DomainName,
+    string[]? Variables
 );

--- a/EvilGiraf/Extensions/ApplicationExtensions.cs
+++ b/EvilGiraf/Extensions/ApplicationExtensions.cs
@@ -15,7 +15,7 @@ public static class ApplicationExtensions
             application.Version,
             application.Port,
             application.DomainName,
-            application.Variables.ToArray()
+            application.Variables?.ToArray() ?? []
         );
     }
 

--- a/EvilGiraf/Extensions/ApplicationExtensions.cs
+++ b/EvilGiraf/Extensions/ApplicationExtensions.cs
@@ -14,7 +14,8 @@ public static class ApplicationExtensions
             application.Link,
             application.Version,
             application.Port,
-            application.DomainName
+            application.DomainName,
+            application.Variables.ToArray()
         );
     }
 
@@ -27,7 +28,8 @@ public static class ApplicationExtensions
             Link = applicationDto.Link,
             Version = applicationDto.Version,
             Port = applicationDto.Port,
-            DomainName = applicationDto.DomainName
+            DomainName = applicationDto.DomainName,
+            Variables = applicationDto.Variables?.ToList() ?? []
         };
     }
 }

--- a/EvilGiraf/Interface/Kubernetes/ConfigMapService.cs
+++ b/EvilGiraf/Interface/Kubernetes/ConfigMapService.cs
@@ -1,0 +1,13 @@
+using EvilGiraf.Model.Kubernetes;
+using k8s.Models;
+
+namespace EvilGiraf.Interface.Kubernetes;
+
+public interface IConfigMapService
+{
+    Task<V1ConfigMap> CreateConfigMap(ConfigMapModel model);
+    Task<V1ConfigMap?> ReadConfigMap(string name, string @namespace);
+    Task<V1ConfigMap?> UpdateConfigMap(ConfigMapModel model);
+    Task<V1Status?> DeleteConfigMap(string name, string @namespace);
+    Task<V1ConfigMap?> CreateOrReplaceConfigMap(ConfigMapModel model);
+}

--- a/EvilGiraf/Interface/Kubernetes/IDeploymentService.cs
+++ b/EvilGiraf/Interface/Kubernetes/IDeploymentService.cs
@@ -1,4 +1,4 @@
-using EvilGiraf.Model;
+using EvilGiraf.Model.Kubernetes;
 using k8s.Models;
 
 namespace EvilGiraf.Interface.Kubernetes;

--- a/EvilGiraf/Interface/Kubernetes/IIngressService.cs
+++ b/EvilGiraf/Interface/Kubernetes/IIngressService.cs
@@ -1,7 +1,7 @@
-using EvilGiraf.Model;
+using EvilGiraf.Model.Kubernetes;
 using k8s.Models;
 
-namespace EvilGiraf.Interface;
+namespace EvilGiraf.Interface.Kubernetes;
 
 public interface IIngressService
 {

--- a/EvilGiraf/Interface/Kubernetes/IServiceService.cs
+++ b/EvilGiraf/Interface/Kubernetes/IServiceService.cs
@@ -1,7 +1,7 @@
-using EvilGiraf.Model;
+using EvilGiraf.Model.Kubernetes;
 using k8s.Models;
 
-namespace EvilGiraf.Interface;
+namespace EvilGiraf.Interface.Kubernetes;
 
 public interface IServiceService
 {

--- a/EvilGiraf/Migrations/20250414181507_ApplicationVariables.Designer.cs
+++ b/EvilGiraf/Migrations/20250414181507_ApplicationVariables.Designer.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using EvilGiraf.Service;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace EvilGiraf.Migrations
 {
     [DbContext(typeof(DatabaseService))]
-    partial class DatabaseServiceModelSnapshot : ModelSnapshot
+    [Migration("20250414181507_ApplicationVariables")]
+    partial class ApplicationVariables
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/EvilGiraf/Migrations/20250414181507_ApplicationVariables.cs
+++ b/EvilGiraf/Migrations/20250414181507_ApplicationVariables.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EvilGiraf.Migrations
+{
+    /// <inheritdoc />
+    public partial class ApplicationVariables : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<List<string>>(
+                name: "Variables",
+                table: "Applications",
+                type: "text[]",
+                nullable: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Variables",
+                table: "Applications");
+        }
+    }
+}

--- a/EvilGiraf/Migrations/20250414203029_ApplicationVariables.Designer.cs
+++ b/EvilGiraf/Migrations/20250414203029_ApplicationVariables.Designer.cs
@@ -12,7 +12,7 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace EvilGiraf.Migrations
 {
     [DbContext(typeof(DatabaseService))]
-    [Migration("20250414181507_ApplicationVariables")]
+    [Migration("20250414203029_ApplicationVariables")]
     partial class ApplicationVariables
     {
         /// <inheritdoc />
@@ -54,7 +54,6 @@ namespace EvilGiraf.Migrations
                         .HasColumnType("integer");
 
                     b.PrimitiveCollection<List<string>>("Variables")
-                        .IsRequired()
                         .HasColumnType("text[]");
 
                     b.Property<string>("Version")

--- a/EvilGiraf/Migrations/20250414203029_ApplicationVariables.cs
+++ b/EvilGiraf/Migrations/20250414203029_ApplicationVariables.cs
@@ -15,7 +15,7 @@ namespace EvilGiraf.Migrations
                 name: "Variables",
                 table: "Applications",
                 type: "text[]",
-                nullable: false);
+                nullable: true);
         }
 
         /// <inheritdoc />

--- a/EvilGiraf/Migrations/DatabaseServiceModelSnapshot.cs
+++ b/EvilGiraf/Migrations/DatabaseServiceModelSnapshot.cs
@@ -51,7 +51,6 @@ namespace EvilGiraf.Migrations
                         .HasColumnType("integer");
 
                     b.PrimitiveCollection<List<string>>("Variables")
-                        .IsRequired()
                         .HasColumnType("text[]");
 
                     b.Property<string>("Version")

--- a/EvilGiraf/Model/Application.cs
+++ b/EvilGiraf/Model/Application.cs
@@ -24,4 +24,6 @@ public class Application
 
     [MaxLength(255)]
     public string? DomainName { get; set; }
+
+    public List<string> Variables { get; set; } = new();
 }

--- a/EvilGiraf/Model/Application.cs
+++ b/EvilGiraf/Model/Application.cs
@@ -25,5 +25,5 @@ public class Application
     [MaxLength(255)]
     public string? DomainName { get; set; }
 
-    public List<string> Variables { get; set; } = new();
+    public List<string>? Variables { get; set; }
 }

--- a/EvilGiraf/Model/Kubernetes/ConfigMapModel.cs
+++ b/EvilGiraf/Model/Kubernetes/ConfigMapModel.cs
@@ -1,0 +1,24 @@
+using k8s.Models;
+
+namespace EvilGiraf.Model.Kubernetes;
+
+public record ConfigMapModel(string Name, string Namespace, List<string> Data);
+
+public static class ConfigMapModelExtensions
+{
+    public static V1ConfigMap ToConfigMap(this ConfigMapModel model)
+    {
+        return new V1ConfigMap
+        {
+            Metadata = new V1ObjectMeta
+            {
+                Name = model.Name
+            },
+            Data = model.Data.Count > 0 ? model.Data.Select(w =>
+            {
+                var words = w.Split('=', 2);
+                return new KeyValuePair<string,string>(words[0], words[1]);
+            }).ToDictionary() : null
+        };
+    }
+}

--- a/EvilGiraf/Model/Kubernetes/DeploymentModel.cs
+++ b/EvilGiraf/Model/Kubernetes/DeploymentModel.cs
@@ -1,8 +1,8 @@
 using k8s.Models;
 
-namespace EvilGiraf.Model;
+namespace EvilGiraf.Model.Kubernetes;
 
-public record DeploymentModel(string Name, string Namespace, int Replicas, string Image, int? Port);
+public record DeploymentModel(string Name, string Namespace, int Replicas, string Image, int? Port, string? ConfigMap);
 
 public static class DeploymentModelExtensions
 {
@@ -45,7 +45,10 @@ public static class DeploymentModelExtensions
                                 Image = model.Image,
                                 Ports = model.Port is null ?
                                     new List<V1ContainerPort>() :
-                                    new List<V1ContainerPort>{new(model.Port.Value)}
+                                    new List<V1ContainerPort>{new(model.Port.Value)},
+                                EnvFrom = model.ConfigMap is null ?
+                                    new List<V1EnvFromSource>() :
+                                    new List<V1EnvFromSource>{new(new V1ConfigMapEnvSource(model.ConfigMap))}
                             }
                         }
                     }

--- a/EvilGiraf/Model/Kubernetes/IngressModel.cs
+++ b/EvilGiraf/Model/Kubernetes/IngressModel.cs
@@ -1,6 +1,6 @@
 using k8s.Models;
 
-namespace EvilGiraf.Model;
+namespace EvilGiraf.Model.Kubernetes;
 
 public record IngressModel(
     string Name,

--- a/EvilGiraf/Model/Kubernetes/ServiceModel.cs
+++ b/EvilGiraf/Model/Kubernetes/ServiceModel.cs
@@ -1,6 +1,6 @@
 using k8s.Models;
 
-namespace EvilGiraf.Model;
+namespace EvilGiraf.Model.Kubernetes;
 
 public record ServiceModel(string Name, string Namespace, int Port);
 

--- a/EvilGiraf/Program.cs
+++ b/EvilGiraf/Program.cs
@@ -70,6 +70,7 @@ public class Program
         builder.Services.AddScoped<IServiceService, ServiceService>();
         builder.Services.AddScoped<IGitBuildService, GitBuildService>();
         builder.Services.AddScoped<IIngressService, IngressService>();
+        builder.Services.AddScoped<IConfigMapService, ConfigMapService>();
 
         var app = builder.Build();
 

--- a/EvilGiraf/Service/ApplicationService.cs
+++ b/EvilGiraf/Service/ApplicationService.cs
@@ -52,6 +52,8 @@ public class ApplicationService(DatabaseService databaseService) : IApplicationS
                     applicationUpdateDto.Port;
         if (applicationUpdateDto.DomainName is not null)
             application.DomainName = applicationUpdateDto.DomainName;
+        if (applicationUpdateDto.Variables is not null)
+            application.Variables = applicationUpdateDto.Variables.ToList();
 
         var updatedApp = databaseService.Applications.Update(application).Entity;
         await databaseService.SaveChangesAsync();

--- a/EvilGiraf/Service/GitBuildService.cs
+++ b/EvilGiraf/Service/GitBuildService.cs
@@ -2,6 +2,7 @@ using System.Text;
 using System.Text.Json;
 using EvilGiraf.Interface;
 using EvilGiraf.Model;
+using EvilGiraf.Model.Kubernetes;
 using k8s;
 using k8s.Autorest;
 using k8s.Models;

--- a/EvilGiraf/Service/Kubernetes/ConfigMapService.cs
+++ b/EvilGiraf/Service/Kubernetes/ConfigMapService.cs
@@ -1,0 +1,59 @@
+using EvilGiraf.Interface.Kubernetes;
+using EvilGiraf.Model.Kubernetes;
+using k8s;
+using k8s.Autorest;
+using k8s.Models;
+
+namespace EvilGiraf.Service.Kubernetes;
+
+public class ConfigMapService(IKubernetes client) : IConfigMapService
+{
+    public async Task<V1ConfigMap> CreateConfigMap(ConfigMapModel model)
+    {
+        return await client.CoreV1.CreateNamespacedConfigMapAsync(model.ToConfigMap(), model.Namespace);
+    }
+
+    public async Task<V1ConfigMap?> ReadConfigMap(string name, string @namespace)
+    {
+        try
+        {
+            return await client.CoreV1.ReadNamespacedConfigMapAsync(name, @namespace);
+        }
+        catch (HttpOperationException ex) when (ex.Response.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            return null;
+        }
+    }
+
+    public async Task<V1ConfigMap?> UpdateConfigMap(ConfigMapModel model)
+    {
+        try
+        {
+            return await client.CoreV1.ReplaceNamespacedConfigMapAsync(model.ToConfigMap(), model.Name, model.Namespace);
+        }
+        catch (HttpOperationException ex) when (ex.Response.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            return null;
+        }
+    }
+
+    public async Task<V1Status?> DeleteConfigMap(string name, string @namespace)
+    {
+        try
+        {
+            return await client.CoreV1.DeleteNamespacedConfigMapAsync(name, @namespace);
+        }
+        catch (HttpOperationException ex) when (ex.Response.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            return null;
+        }
+    }
+
+    public async Task<V1ConfigMap?> CreateOrReplaceConfigMap(ConfigMapModel model)
+    {
+        var configMap = await ReadConfigMap(model.Name, model.Namespace);
+        if (configMap is not null)
+            return await UpdateConfigMap(model);
+        return await CreateConfigMap(model);
+    }
+}

--- a/EvilGiraf/Service/Kubernetes/DeploymentService.cs
+++ b/EvilGiraf/Service/Kubernetes/DeploymentService.cs
@@ -1,5 +1,5 @@
 using EvilGiraf.Interface.Kubernetes;
-using EvilGiraf.Model;
+using EvilGiraf.Model.Kubernetes;
 using k8s;
 using k8s.Autorest;
 using k8s.Models;

--- a/EvilGiraf/Service/Kubernetes/IngressService.cs
+++ b/EvilGiraf/Service/Kubernetes/IngressService.cs
@@ -1,6 +1,5 @@
-using EvilGiraf.Interface;
 using EvilGiraf.Interface.Kubernetes;
-using EvilGiraf.Model;
+using EvilGiraf.Model.Kubernetes;
 using k8s;
 using k8s.Autorest;
 using k8s.Models;

--- a/EvilGiraf/Service/Kubernetes/ServiceService.cs
+++ b/EvilGiraf/Service/Kubernetes/ServiceService.cs
@@ -1,5 +1,5 @@
-using EvilGiraf.Interface;
-using EvilGiraf.Model;
+using EvilGiraf.Interface.Kubernetes;
+using EvilGiraf.Model.Kubernetes;
 using k8s;
 using k8s.Autorest;
 using k8s.Models;

--- a/EvilGiraf/Service/KubernetesService.cs
+++ b/EvilGiraf/Service/KubernetesService.cs
@@ -1,10 +1,11 @@
 using EvilGiraf.Interface;
 using EvilGiraf.Interface.Kubernetes;
 using EvilGiraf.Model;
+using EvilGiraf.Model.Kubernetes;
 
 namespace EvilGiraf.Service;
 
-public class KubernetesService(IDeploymentService deploymentService, INamespaceService namespaceService, IServiceService serviceService, IGitBuildService gitBuildService, IIngressService ingressService) : IKubernetesService
+public class KubernetesService(IDeploymentService deploymentService, INamespaceService namespaceService, IServiceService serviceService, IGitBuildService gitBuildService, IIngressService ingressService, IConfigMapService configMapService) : IKubernetesService
 {
     public async Task Deploy(Application app, int timeoutSeconds = 600)
     {
@@ -19,6 +20,7 @@ public class KubernetesService(IDeploymentService deploymentService, INamespaceS
 
         var existed = await HandleDeployment(app, imageLink);
         await HandleServiceAndIngress(app, existed);
+        await HandleConfigmaps(app);
     }
     
     private async Task<string?> GetImageLink(Application app, int timeoutSeconds)
@@ -34,7 +36,7 @@ public class KubernetesService(IDeploymentService deploymentService, INamespaceS
     private async Task<bool> HandleDeployment(Application app, string imageLink)
     {
         var deployment = await deploymentService.ReadDeployment(app.Name, app.Id.ToNamespace());
-        var deploymentModel = new DeploymentModel(app.Name, app.Id.ToNamespace(), 1, imageLink, app.Port);
+        var deploymentModel = new DeploymentModel(app.Name, app.Id.ToNamespace(), 1, imageLink, app.Port, app.Variables.Count > 0 ? app.Name : null);
         
         if (deployment is null)
         {
@@ -73,6 +75,20 @@ public class KubernetesService(IDeploymentService deploymentService, INamespaceS
                 await ingressService.CreateIngress(ingressModel);
             }
         }
+    }
+    
+    private async Task HandleConfigmaps(Application app)
+    {
+        if (app.Variables.Count == 0)
+        {
+            await configMapService.DeleteConfigMap(app.Name, app.Id.ToNamespace());
+            return;
+        }
+            
+        var configModel = new ConfigMapModel(app.Name, app.Id.ToNamespace(), app.Variables);
+        
+        await configMapService.CreateOrReplaceConfigMap(configModel);
+            
     }
     
     public async Task Undeploy(Application app)

--- a/EvilGiraf/Service/KubernetesService.cs
+++ b/EvilGiraf/Service/KubernetesService.cs
@@ -36,7 +36,7 @@ public class KubernetesService(IDeploymentService deploymentService, INamespaceS
     private async Task<bool> HandleDeployment(Application app, string imageLink)
     {
         var deployment = await deploymentService.ReadDeployment(app.Name, app.Id.ToNamespace());
-        var deploymentModel = new DeploymentModel(app.Name, app.Id.ToNamespace(), 1, imageLink, app.Port, app.Variables.Count > 0 ? app.Name : null);
+        var deploymentModel = new DeploymentModel(app.Name, app.Id.ToNamespace(), 1, imageLink, app.Port, app.Variables is null || app.Variables.Count == 0 ? null : app.Name);
         
         if (deployment is null)
         {
@@ -79,7 +79,7 @@ public class KubernetesService(IDeploymentService deploymentService, INamespaceS
     
     private async Task HandleConfigmaps(Application app)
     {
-        if (app.Variables.Count == 0)
+        if (app.Variables is null || app.Variables.Count == 0)
         {
             await configMapService.DeleteConfigMap(app.Name, app.Id.ToNamespace());
             return;


### PR DESCRIPTION
Introduced ConfigMap management in the Kubernetes service, allowing creation, updating, and deletion of ConfigMaps based on application variables. Updated application DTOs, models, and tests to support the new functionality. Refactored namespace imports and extended test coverage for ConfigMap operations.

Closes #80 