### PR TITLE
fix: add Docker registry configuration to API deployment

### DIFF
--- a/.github/workflows/CD.yaml
+++ b/.github/workflows/CD.yaml
@@ -59,6 +59,9 @@ jobs:
             --set front.image.tag=${{ steps.version.outputs.semVer }} \
             --set api.auth.apiKey=${{ secrets.API_KEY }} \
             --set postgresql.auth.password=${{ secrets.POSTGRES_PASSWORD }} \
+            --set api.dockerRegistry.url=${{ secrets.REGISTRY_URL }} \
+            --set api.dockerRegistry.username=${{ secrets.REGISTRY_USERNAME }} \
+            --set api.dockerRegistry.password=${{ secrets.REGISTRY_PASSWORD }} \
             --wait --timeout 15m
 
       - name: Create Git Tag

--- a/helm-chart/templates/deployment-api.yaml
+++ b/helm-chart/templates/deployment-api.yaml
@@ -75,6 +75,12 @@ spec:
               value: {{ .Values.postgresql.auth.username }}
             - name: POSTGRES__PASSWORD
               value: {{ .Values.postgresql.auth.password }}
+            - name: DockerRegistry__Url
+              value: {{ .Values.api.dockerRegistry.url }}
+            - name: DockerRegistry__Username
+              value: {{ .Values.api.dockerRegistry.username | default "" }}
+            - name: DockerRegistry__Password
+              value: {{ .Values.api.dockerRegistry.password | default "" }}
           livenessProbe:
             {{- toYaml .Values.api.livenessProbe | nindent 12 }}
           readinessProbe:

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -92,6 +92,12 @@ api:
   
   auth:
     apiKey: '***'
+  
+  dockerRegistry:
+    url: "***"
+    username: ""
+    password: ""
+
 
 front:
   nameOverride: ""


### PR DESCRIPTION
Introduce configuration options for Docker registry URL, username, and password in Helm values and GitHub Actions workflow. These values are also set as environment variables in the API deployment template to support authenticated Docker registry access.