### PR TITLE
feat: implement createOrReplace functionality for resources

### DIFF
--- a/EvilGiraf.IntegrationTests/DeploymentControllerTests.cs
+++ b/EvilGiraf.IntegrationTests/DeploymentControllerTests.cs
@@ -132,6 +132,10 @@ public class DeploymentControllerTests : AuthenticatedTestBase
             .Returns(deployment);
         
         _kubernetes.NetworkingV1.ReadNamespacedIngressWithHttpMessagesAsync(Arg.Any<string>(), Arg.Any<string>()).Returns(new HttpOperationResponse<V1Ingress>{ Body = new V1Ingress() });
+        _kubernetes.CoreV1.ReadNamespacedServiceWithHttpMessagesAsync(Arg.Any<string>(), application.Id.ToNamespace()).Returns(new HttpOperationResponse<V1Service>{Body = new V1Service()});
+        _kubernetes.CoreV1.ReplaceNamespacedServiceWithHttpMessagesAsync(Arg.Any<V1Service>(), Arg.Any<string>(), application.Id.ToNamespace()).Returns(new HttpOperationResponse<V1Service>());
+        _kubernetes.NetworkingV1.ReadNamespacedIngressWithHttpMessagesAsync(Arg.Any<string>(), application.Id.ToNamespace()).Returns(new HttpOperationResponse<V1Ingress>{Body = new V1Ingress()});
+        _kubernetes.NetworkingV1.ReplaceNamespacedIngressWithHttpMessagesAsync(Arg.Any<V1Ingress>(), Arg.Any<string>(), application.Id.ToNamespace()).Returns(new HttpOperationResponse<V1Ingress>());
         _kubernetes.CoreV1.ReadNamespacedConfigMapWithHttpMessagesAsync(Arg.Any<string>(), application.Id.ToNamespace()).Returns(new HttpOperationResponse<V1ConfigMap>{Body = new V1ConfigMap()});
         _kubernetes.CoreV1.ReplaceNamespacedConfigMapWithHttpMessagesAsync(Arg.Any<V1ConfigMap>(), Arg.Any<string>(), application.Id.ToNamespace()).Returns(new HttpOperationResponse<V1ConfigMap>());
 
@@ -208,6 +212,10 @@ public class DeploymentControllerTests : AuthenticatedTestBase
         _kubernetes.CoreV1.ReadNamespaceWithHttpMessagesAsync(Arg.Any<string>()).Returns(new HttpOperationResponse<V1Namespace>{ Body = new V1Namespace()});
         
         _kubernetes.NetworkingV1.CreateNamespacedIngressWithHttpMessagesAsync(Arg.Any<V1Ingress>(), application.Id.ToNamespace()).Returns(new HttpOperationResponse<V1Ingress>{ Body = new V1Ingress()});
+        _kubernetes.CoreV1.ReadNamespacedServiceWithHttpMessagesAsync(Arg.Any<string>(), application.Id.ToNamespace()).Returns(new HttpOperationResponse<V1Service>());
+        _kubernetes.CoreV1.CreateNamespacedServiceWithHttpMessagesAsync(Arg.Any<V1Service>(), application.Id.ToNamespace()).Returns(new HttpOperationResponse<V1Service>());
+        _kubernetes.NetworkingV1.ReadNamespacedIngressWithHttpMessagesAsync(Arg.Any<string>(), application.Id.ToNamespace()).Returns(new HttpOperationResponse<V1Ingress>());
+        _kubernetes.NetworkingV1.CreateNamespacedIngressWithHttpMessagesAsync(Arg.Any<V1Ingress>(), application.Id.ToNamespace()).Returns(new HttpOperationResponse<V1Ingress>());
         _kubernetes.CoreV1.ReadNamespacedConfigMapWithHttpMessagesAsync(Arg.Any<string>(), application.Id.ToNamespace()).Returns(new HttpOperationResponse<V1ConfigMap>());
         _kubernetes.CoreV1.CreateNamespacedConfigMapWithHttpMessagesAsync(Arg.Any<V1ConfigMap>(), application.Id.ToNamespace()).Returns(new HttpOperationResponse<V1ConfigMap>());
 
@@ -465,6 +473,8 @@ public class DeploymentControllerTests : AuthenticatedTestBase
         ).Returns(new HttpOperationResponse<V1Deployment>{ Body = new V1Deployment() });
         
         _kubernetes.CoreV1.ReadNamespacedSecretWithHttpMessagesAsync(Arg.Any<string>(), gitApp.Id.ToNamespace()).Returns(new HttpOperationResponse<V1Secret>());
+        _kubernetes.CoreV1.DeleteNamespacedServiceWithHttpMessagesAsync(Arg.Any<string>(), gitApp.Id.ToNamespace()).Returns(new HttpOperationResponse<V1Service>());
+        _kubernetes.NetworkingV1.DeleteNamespacedIngressWithHttpMessagesAsync(Arg.Any<string>(), gitApp.Id.ToNamespace()).Returns(new HttpOperationResponse<V1Status>());
         _kubernetes.CoreV1.DeleteNamespacedConfigMapWithHttpMessagesAsync(Arg.Any<string>(), gitApp.Id.ToNamespace()).Returns(new HttpOperationResponse<V1Status>());
         
         // Act

--- a/EvilGiraf.Tests/IngressTests.cs
+++ b/EvilGiraf.Tests/IngressTests.cs
@@ -325,7 +325,7 @@ public class IngressTests
     }
 
     [Fact]
-    public async Task CreateIfNotExistsIngress_WhenIngressExists_Should_Return_ExistingIngress()
+    public async Task CreateOrReplaceIngress_WhenIngressExists_Should_Replace_ExistingIngress()
     {
         // Arrange
         var model = new IngressModel(
@@ -350,8 +350,14 @@ public class IngressTests
             model.Namespace
         ).Returns(new HttpOperationResponse<V1Ingress> { Body = existingIngress });
 
+        _kubernetes.NetworkingV1.ReplaceNamespacedIngressWithHttpMessagesAsync(
+            Arg.Any<V1Ingress>(),
+            model.Name,
+            model.Namespace
+        ).Returns(new HttpOperationResponse<V1Ingress> { Body = existingIngress });
+
         // Act
-        var result = await _ingressService.CreateIfNotExistsIngress(model);
+        var result = await _ingressService.CreateOrReplaceIngress(model);
 
         // Assert
         result.Should().NotBeNull();
@@ -363,7 +369,7 @@ public class IngressTests
     }
 
     [Fact]
-    public async Task CreateIfNotExistsIngress_WhenIngressNotExists_Should_Create_And_Return_NewIngress()
+    public async Task CreateOrReplaceIngress_WhenIngressNotExists_Should_Create_And_Return_NewIngress()
     {
         // Arrange
         var model = new IngressModel(
@@ -402,7 +408,7 @@ public class IngressTests
             .Returns(new HttpOperationResponse<V1Namespace> { Body = new V1Namespace() });
         
         // Act
-        var result = await _ingressService.CreateIfNotExistsIngress(model);
+        var result = await _ingressService.CreateOrReplaceIngress(model);
 
         // Assert
         result.Should().NotBeNull();

--- a/EvilGiraf.Tests/KubernetesTests.cs
+++ b/EvilGiraf.Tests/KubernetesTests.cs
@@ -49,10 +49,7 @@ public class KubernetesTests
 
         // Assert
         await _deploymentService.Received(1)
-            .ReadDeployment(app.Name, app.Id.ToNamespace());
-        
-        await _deploymentService.Received(1)
-            .CreateDeployment(Arg.Is<DeploymentModel>(d => 
+            .CreateOrReplaceDeployment(Arg.Is<DeploymentModel>(d => 
                 d.Name == app.Name && 
                 d.Namespace == app.Id.ToNamespace() &&
                 d.Image == app.Link &&
@@ -78,13 +75,7 @@ public class KubernetesTests
 
         // Assert
         await _deploymentService.Received(1)
-            .ReadDeployment(app.Name, app.Id.ToNamespace());
-        
-        await _deploymentService.DidNotReceive()
-            .CreateDeployment(Arg.Any<DeploymentModel>());
-        
-        await _deploymentService.Received(1)
-            .UpdateDeployment(Arg.Is<DeploymentModel>(d => 
+            .CreateOrReplaceDeployment(Arg.Is<DeploymentModel>(d => 
                 d.Name == app.Name && 
                 d.Namespace == app.Id.ToNamespace() &&
                 d.Image == app.Link &&
@@ -96,7 +87,7 @@ public class KubernetesTests
     {
         // Arrange
         var app = CreateTestApplication();
-        _deploymentService.ReadDeployment(app.Name, app.Id.ToNamespace())
+        _deploymentService.CreateOrReplaceDeployment(Arg.Any<DeploymentModel>())
             .ThrowsAsync(new Exception("Deployment service error"));
 
         // Act
@@ -105,11 +96,5 @@ public class KubernetesTests
         // Assert
         await act.Should().ThrowAsync<Exception>()
             .WithMessage("Deployment service error");
-        
-        await _deploymentService.DidNotReceive()
-            .CreateDeployment(Arg.Any<DeploymentModel>());
-        
-        await _deploymentService.DidNotReceive()
-            .UpdateDeployment(Arg.Any<DeploymentModel>());
     }
 }

--- a/EvilGiraf/Interface/Kubernetes/IDeploymentService.cs
+++ b/EvilGiraf/Interface/Kubernetes/IDeploymentService.cs
@@ -12,4 +12,6 @@ public interface IDeploymentService
     public Task<V1Deployment?> UpdateDeployment(DeploymentModel model);
     
     public Task<V1Status?> DeleteDeployment(string name, string @namespace);
+    
+    public Task<V1Deployment?> CreateOrReplaceDeployment(DeploymentModel model);
 }

--- a/EvilGiraf/Interface/Kubernetes/IIngressService.cs
+++ b/EvilGiraf/Interface/Kubernetes/IIngressService.cs
@@ -13,5 +13,5 @@ public interface IIngressService
     
     public Task<V1Status?> DeleteIngress(string name, string @namespace);
 
-    public Task<V1Ingress> CreateIfNotExistsIngress(IngressModel model);
+    public Task<V1Ingress?> CreateOrReplaceIngress(IngressModel model);
 }

--- a/EvilGiraf/Interface/Kubernetes/IServiceService.cs
+++ b/EvilGiraf/Interface/Kubernetes/IServiceService.cs
@@ -13,5 +13,5 @@ public interface IServiceService
     
     public Task<V1Service?> DeleteService(string name, string @namespace);
 
-    public Task<V1Service> CreateIfNotExistsService(ServiceModel model);
+    public Task<V1Service?> CreateOrReplaceService(ServiceModel model);
 }

--- a/EvilGiraf/Service/Kubernetes/ConfigMapService.cs
+++ b/EvilGiraf/Service/Kubernetes/ConfigMapService.cs
@@ -51,9 +51,8 @@ public class ConfigMapService(IKubernetes client) : IConfigMapService
 
     public async Task<V1ConfigMap?> CreateOrReplaceConfigMap(ConfigMapModel model)
     {
-        var configMap = await ReadConfigMap(model.Name, model.Namespace);
-        if (configMap is not null)
-            return await UpdateConfigMap(model);
-        return await CreateConfigMap(model);
+        if (await ReadConfigMap(model.Name, model.Namespace) is null)
+            return await CreateConfigMap(model);
+        return await UpdateConfigMap(model);
     }
 }

--- a/EvilGiraf/Service/Kubernetes/DeploymentService.cs
+++ b/EvilGiraf/Service/Kubernetes/DeploymentService.cs
@@ -49,4 +49,11 @@ public class DeploymentService(IKubernetes client) : IDeploymentService
             return null;
         }
     }
+    
+    public async Task<V1Deployment?> CreateOrReplaceDeployment(DeploymentModel model)
+    {
+        if (await ReadDeployment(model.Name, model.Namespace) is null)
+            return await CreateDeployment(model);
+        return await UpdateDeployment(model);
+    }
 }

--- a/EvilGiraf/Service/Kubernetes/IngressService.cs
+++ b/EvilGiraf/Service/Kubernetes/IngressService.cs
@@ -49,11 +49,10 @@ public class IngressService(IKubernetes client) : IIngressService
         }
     }
 
-    public async Task<V1Ingress> CreateIfNotExistsIngress(IngressModel model)
+    public async Task<V1Ingress?> CreateOrReplaceIngress(IngressModel model)
     {
-        var ingress = await ReadIngress(model.Name, model.Namespace);
-        if (ingress != null)
-            return ingress;
-        return await CreateIngress(model);
+        if (await ReadIngress(model.Name, model.Namespace) is null)
+            return await CreateIngress(model);
+        return await UpdateIngress(model);
     }
 }

--- a/EvilGiraf/Service/Kubernetes/ServiceService.cs
+++ b/EvilGiraf/Service/Kubernetes/ServiceService.cs
@@ -49,10 +49,10 @@ public class ServiceService(IKubernetes client) : IServiceService
         }
     }
 
-    public async Task<V1Service> CreateIfNotExistsService(ServiceModel model)
+    public async Task<V1Service?> CreateOrReplaceService(ServiceModel model)
     {
-        if (await ReadService(model.Name, model.Namespace) is { } service)
-            return service;
-        return await CreateService(model);
+        if (await ReadService(model.Name, model.Namespace) is null)
+            return await CreateService(model);
+        return await UpdateService(model);
     }
 }


### PR DESCRIPTION
Refactored `CreateIfNotExists` methods to `CreateOrReplace` for deployments, services, ingress, and config maps to streamline resource management. Updated tests accordingly to reflect the new behavior and ensure proper replacements or creations are handled consistently across resources.

Closes #157 
Closes #158 