### PR TITLE
feat: add support for custom ingress annotations

### DIFF
--- a/EvilGiraf.Tests/IngressTests.cs
+++ b/EvilGiraf.Tests/IngressTests.cs
@@ -5,6 +5,7 @@ using FluentAssertions;
 using k8s;
 using k8s.Autorest;
 using k8s.Models;
+using Microsoft.Extensions.Configuration;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 
@@ -18,7 +19,7 @@ public class IngressTests
     public IngressTests()
     {
         _kubernetes = Substitute.For<IKubernetes>();
-        _ingressService = new IngressService(_kubernetes);
+        _ingressService = new IngressService(_kubernetes, Substitute.For<IConfiguration>());
     }
 
     [Fact]

--- a/EvilGiraf/Model/Kubernetes/IngressModel.cs
+++ b/EvilGiraf/Model/Kubernetes/IngressModel.cs
@@ -7,7 +7,8 @@ public record IngressModel(
     string Namespace,
     string Host,
     int Port,
-    string Path
+    string Path,
+    Dictionary<string, string>? Annotations = null
 );
 
 public static class IngressModelExtensions
@@ -19,7 +20,8 @@ public static class IngressModelExtensions
             Metadata = new V1ObjectMeta
             {
                 Name = model.Name,
-                NamespaceProperty = model.Namespace
+                NamespaceProperty = model.Namespace,
+                Annotations = model.Annotations
             },
             Spec = new V1IngressSpec
             {
@@ -50,6 +52,14 @@ public static class IngressModelExtensions
                                 }
                             }
                         }
+                    }
+                },
+                Tls = new List<V1IngressTLS>
+                {
+                    new()
+                    {
+                        Hosts = new List<string>{model.Host},
+                        SecretName = $"{model.Name}-tls-secret"
                     }
                 }
             }

--- a/EvilGiraf/appsettings.json
+++ b/EvilGiraf/appsettings.json
@@ -10,5 +10,6 @@
     "Url": "your-registry.example.com",
     "Username": "",
     "Password": ""
-  }
+  },
+  "IngressAnnotations": { }
 }

--- a/helm-chart/templates/deployment-api.yaml
+++ b/helm-chart/templates/deployment-api.yaml
@@ -81,6 +81,10 @@ spec:
               value: {{ .Values.api.dockerRegistry.username | default "" }}
             - name: DockerRegistry__Password
               value: {{ .Values.api.dockerRegistry.password | default "" }}
+            {{- range $key, $value := .Values.api.ingressAnnotations }}
+            - name: IngressAnnotations__{{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
           livenessProbe:
             {{- toYaml .Values.api.livenessProbe | nindent 12 }}
           readinessProbe:

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -97,6 +97,14 @@ api:
     url: "***"
     username: ""
     password: ""
+    
+  ingressAnnotations:
+    # Example annotations
+    "cert-manager.io/cluster-issuer": "letsencrypt",
+    "spec.ingressClassName": "traefik",
+    "traefik.ingress.kubernetes.io/router.entrypoints": "web, websecure",
+    "traefik.ingress.kubernetes.io/router.tls": "true",
+    "traefik.ingress.kubernetes.io/router.middlewares": "default-redirect-https@kubernetescrd"
 
 
 front:


### PR DESCRIPTION
Introduced the ability to define custom annotations for Kubernetes ingress objects by integrating configuration support. Updated `IngressService`, model, templates, and tests to handle annotations and TLS configurations dynamically. This enhancement improves flexibility and ease of management for ingress resources.

Closes #153 