### PR TITLE
refactor: remove Helm chart ingress annotations configuration

### DIFF
--- a/EvilGiraf/appsettings.json
+++ b/EvilGiraf/appsettings.json
@@ -11,5 +11,11 @@
     "Username": "",
     "Password": ""
   },
-  "IngressAnnotations": { }
+  "IngressAnnotations": {
+    "cert-manager.io/cluster-issuer": "letsencrypt",
+    "spec.ingressClassName": "traefik",
+    "traefik.ingress.kubernetes.io/router.entrypoints": "web, websecure",
+    "traefik.ingress.kubernetes.io/router.tls": "true",
+    "traefik.ingress.kubernetes.io/router.middlewares": "default-redirect-https@kubernetescrd"
+  }
 }

--- a/helm-chart/templates/deployment-api.yaml
+++ b/helm-chart/templates/deployment-api.yaml
@@ -81,10 +81,6 @@ spec:
               value: {{ .Values.api.dockerRegistry.username | default "" }}
             - name: DockerRegistry__Password
               value: {{ .Values.api.dockerRegistry.password | default "" }}
-            {{- range $key, $value := .Values.api.ingressAnnotations }}
-            - name: IngressAnnotations__{{ $key }}
-              value: {{ $value | quote }}
-            {{- end }}
           livenessProbe:
             {{- toYaml .Values.api.livenessProbe | nindent 12 }}
           readinessProbe:

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -97,15 +97,6 @@ api:
     url: "***"
     username: ""
     password: ""
-    
-  ingressAnnotations:
-    # Example annotations
-    "cert-manager.io/cluster-issuer": "letsencrypt",
-    "spec.ingressClassName": "traefik",
-    "traefik.ingress.kubernetes.io/router.entrypoints": "web, websecure",
-    "traefik.ingress.kubernetes.io/router.tls": "true",
-    "traefik.ingress.kubernetes.io/router.middlewares": "default-redirect-https@kubernetescrd"
-
 
 front:
   nameOverride: ""


### PR DESCRIPTION
Ingress annotations logic was removed from Helm chart values and templates, streamlining configuration. These annotations are now directly defined in `appsettings.json`, centralizing their management. This simplifies the deployment process and avoids redundant configuration.