### PR TITLE
feat: add permissions for batch jobs

### DIFF
--- a/helm-chart/templates/rbac-front.yaml
+++ b/helm-chart/templates/rbac-front.yaml
@@ -17,6 +17,10 @@ rules:
   - apiGroups: ["apps"]
     resources: ["deployments"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
Expanded RBAC rules to include permissions for managing batch jobs. This allows the service to get, list, watch, create, update, patch, and delete job resources.