### PR TITLE
fix: front ensure synchronous deployment by default

### DIFF
--- a/EvilGiraf.Front/src/lib/api.ts
+++ b/EvilGiraf.Front/src/lib/api.ts
@@ -76,7 +76,7 @@ export const api = {
   
   deployments: {
     deploy: async (id: number): Promise<void> => {
-      const response = await fetch(`${API_URL}/deploy/${id}`, {
+      const response = await fetch(`${API_URL}/deploy/${id}?isAsync=false`, {
         method: 'POST',
         headers: getHeaders(),
       });


### PR DESCRIPTION
Added `isAsync=false` query parameter to deployment API calls to ensure deployments are handled synchronously. This avoids potential issues caused by asynchronous processing in certain workflows.