### PR TITLE
fix: adjust job permissions between front and api roles

### DIFF
--- a/helm-chart/templates/rbac-api.yaml
+++ b/helm-chart/templates/rbac-api.yaml
@@ -17,6 +17,9 @@ rules:
   - apiGroups: ["apps"]
     resources: ["deployments"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/helm-chart/templates/rbac-front.yaml
+++ b/helm-chart/templates/rbac-front.yaml
@@ -17,9 +17,6 @@ rules:
   - apiGroups: ["apps"]
     resources: ["deployments"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-  - apiGroups: ["batch"]
-    resources: ["jobs"]
-    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Removed job-related permissions from the front role and added them to the api role. This ensures proper alignment of RBAC configurations with their respective responsibilities. No functional changes expected outside of corrected scoping.